### PR TITLE
Allow struct fields be named as 'name' (issue #21)

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -350,3 +350,21 @@ fn de_attribute_enum() {
     }
   );
 }
+
+#[test]
+fn de_name_issue_21() {
+  #[derive(YaDeserialize, PartialEq, Debug)]
+  #[yaserde(root = "book")]
+  pub struct Book {
+    name: String,
+  }
+
+  let content = "<book><name>Little prince</name></book>";
+  convert_and_validate!(
+    content,
+    Book,
+    Book {
+      name: String::from("Little prince"),
+    }
+  );
+}

--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -298,3 +298,19 @@ fn ser_attribute_enum() {
   let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><base color=\"pink\" />";
   convert_and_validate!(model, content);
 }
+
+#[test]
+fn ser_name_issue_21() {
+  #[derive(YaSerialize, PartialEq, Debug)]
+  #[yaserde(root = "base")]
+  pub struct XmlStruct {
+    name: String,
+  }
+
+  let model = XmlStruct {
+    name: "something".to_string(),
+  };
+
+  let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><base><name>something</name></base>";
+  convert_and_validate!(model, content);
+}


### PR DESCRIPTION
Hey everyone!

To prevent clashing I extended names of internal mut variables used for field initialization

For example after cargo expand:
Before (was clashing with `XmlNode::SomeType { name, .. }`):
```rust
#[allow(unused_mut)]
let mut name: String = "".to_string();

...

if let Ok(value) = result {
  name = value
}

...

Ok(Book { name: name })
```

After:
```rust
#[allow(unused_mut)]
let mut __name_value: String = "".to_string();

...

if let Ok(value) = result {
  __name_value = value
}

...

Ok(Book { name: __name_value })
```

Issue #21 