### PR TITLE
Fix custom serializer

### DIFF
--- a/yaserde/tests/se_default.rs
+++ b/yaserde/tests/se_default.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate log;
 extern crate xml;
 extern crate yaserde;

--- a/yaserde/tests/se_namespace.rs
+++ b/yaserde/tests/se_namespace.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate log;
 extern crate xml;
 extern crate yaserde;

--- a/yaserde/tests/se_option.rs
+++ b/yaserde/tests/se_option.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate log;
 extern crate xml;
 extern crate yaserde;

--- a/yaserde/tests/se_type.rs
+++ b/yaserde/tests/se_type.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate log;
 extern crate xml;
 extern crate yaserde;


### PR DESCRIPTION
Hey!
I've simplified the process of writing custom serializers a bit. Previously custom serializer was called twice and user had to check against `get_start_event_name()` and return Ok(()):

```rust
fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>)
  -> Result<(), String> {
  if let Some(label) = writer.get_start_event_name() {
    let struct_start_event = XmlEvent::start_element(label.as_ref());
    let _ret = writer.write(struct_start_event);
    return Ok(());
  }
  ...
```
So at the first `serialize()` call user checks that there is a start_event_name, returns and immediately receives the second `serialize()` call in which user continues his job.

What if we change this a bit? 
1. User function can be called only once and everything can be serialized in a single call. 
2. In general case user should check against writer internal state (`writer.get_start_event_name()` and `writer.skip_start_end()`) as well and serialize accordingly. But in a simple case user does not need all of this. I've added a test in serializer/tests to show what I mean.

And related minor changes:
```rust
if let Err(msg) = item.serialize(writer) {
  return Err(msg);
};
```
is replaced with
```rust
item.serialize(writer)?;
```

Every call to `.serialize(writer)` inside the library is prepended with writer setup to ensure that needed flags are set to what we need, for example:
```rust
writer.set_start_event_name(Some(#field_label_name.to_string()));
writer.set_skip_start_end(false);
#field_label.serialize(writer)?;
```