### PR TITLE
Fix unnamed enum variants ignored namespace prefix while serializing

### DIFF
--- a/yaserde/tests/se_namespace.rs
+++ b/yaserde/tests/se_namespace.rs
@@ -47,11 +47,18 @@ fn ser_enum_namespace() {
   pub enum XmlStruct {
     #[yaserde(prefix = "ns")]
     Item,
+    #[yaserde(prefix = "ns")]
+    ItemWithField(String),
   }
 
   let model = XmlStruct::Item;
 
   let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><ns:root xmlns:ns=\"http://www.sample.com/ns/domain\">ns:Item</ns:root>";
+  convert_and_validate!(model, content);
+
+  let model = XmlStruct::ItemWithField("Value".to_string());
+
+  let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><ns:root xmlns:ns=\"http://www.sample.com/ns/domain\"><ns:ItemWithField>Value</ns:ItemWithField></ns:root>";
   convert_and_validate!(model, content);
 }
 


### PR DESCRIPTION
Hello!
Tiny fix for the case when a 'prefix' is provided for enum variant with unnamed field. Prefix got lost and did not appear in the output.

```rust
  pub enum XmlStruct {
    #[yaserde(prefix = "ns")]
    ItemWithField(String),
  }
```