### PR TITLE
Fix compilation errors when element name contains dots

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -181,6 +181,8 @@ fn de_rename() {
     item: String,
     #[yaserde(rename = "sub")]
     sub_struct: SubStruct,
+    #[yaserde(rename = "maj.min.bug")]
+    with_dots: String,
   }
 
   #[derive(YaDeserialize, PartialEq, Debug)]
@@ -198,7 +200,7 @@ fn de_rename() {
     }
   }
 
-  let content = "<base Item=\"something\"><sub sub_item=\"sub_something\"></sub></base>";
+  let content = "<base Item=\"something\"><sub sub_item=\"sub_something\"></sub><maj.min.bug>2.0.1</maj.min.bug></base>";
   convert_and_validate!(
     content,
     XmlStruct,
@@ -207,6 +209,7 @@ fn de_rename() {
       sub_struct: SubStruct {
         subitem: "sub_something".to_string(),
       },
+      with_dots: "2.0.1".into()
     }
   );
 }
@@ -378,6 +381,8 @@ fn de_complex_enum() {
     Magenta(Vec<OtherStruct>),
     #[yaserde(rename = "NotSoCyan")]
     Cyan(Vec<OtherStruct>),
+    #[yaserde(rename = "renamed.with.dots")]
+    Dotted(u32),
   }
 
   impl Default for Color {
@@ -549,6 +554,21 @@ fn de_complex_enum() {
         OtherStruct { fi: 12, se: 23 },
         OtherStruct { fi: 63, se: 98 }
       ])
+    }
+  );
+
+  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+    <base xmlns:ns="http://www.sample.com/ns/domain">
+      <background>
+        <renamed.with.dots>54</renamed.with.dots>
+      </background>
+    </base>
+  "#;
+  convert_and_validate!(
+    content,
+    XmlStruct,
+    XmlStruct {
+      background: Color::Dotted(54)
     }
   );
 }

--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -125,6 +125,8 @@ fn ser_rename() {
     item: String,
     #[yaserde(rename = "sub")]
     sub_struct: SubStruct,
+    #[yaserde(rename = "maj.min.bug")]
+    version: String,
   }
 
   #[derive(YaSerialize, PartialEq, Debug)]
@@ -154,9 +156,10 @@ fn ser_rename() {
     sub_struct: SubStruct {
       subitem: "sub_something".to_string(),
     },
+    version: "2.0.2".into(),
   };
 
-  let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><base Item=\"something\"><sub sub_item=\"sub_something\" /></base>";
+  let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><base Item=\"something\"><sub sub_item=\"sub_something\" /><maj.min.bug>2.0.2</maj.min.bug></base>";
   convert_and_validate!(model, content);
 }
 
@@ -326,6 +329,8 @@ fn ser_unnamed_enum() {
     Structs(Vec<OtherStruct>),
     #[yaserde(rename = "renamed")]
     ToRename(u32),
+    #[yaserde(rename = "renamed.with.dots")]
+    ToRenameDots(u32),
   }
 
   impl Default for Enum {
@@ -421,6 +426,14 @@ fn ser_unnamed_enum() {
 
   let content =
     "<?xml version=\"1.0\" encoding=\"utf-8\"?><base><color><renamed>87</renamed></color></base>";
+  convert_and_validate!(model, content);
+
+  let model = XmlStruct {
+    color: Enum::ToRenameDots(84),
+  };
+
+  let content =
+    "<?xml version=\"1.0\" encoding=\"utf-8\"?><base><color><renamed.with.dots>84</renamed.with.dots></color></base>";
   convert_and_validate!(model, content);
 }
 

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -24,16 +24,9 @@ pub fn serialize(
         return None;
       }
 
-      let renamed_label = match field_attrs.rename {
-        Some(value) => Ident::new(&value, Span::call_site()),
-        None => field.ident.clone().unwrap(),
-      };
       let label = &field.ident;
-      let label_name = if let Some(prefix) = field_attrs.prefix {
-        prefix + ":" + renamed_label.to_string().as_ref()
-      } else {
-        renamed_label.to_string()
-      };
+
+      let label_name = build_label_name(&field, &field_attrs);
 
       match get_field_type(field) {
         Some(FieldType::FieldTypeString)
@@ -270,16 +263,7 @@ pub fn serialize(
         ));
       }
 
-      let renamed_label = match field_attrs.rename {
-        Some(value) => Ident::new(&value, Span::call_site()),
-        None => field.ident.clone().unwrap(),
-      };
-
-      let label_name = if let Some(prefix) = field_attrs.prefix {
-        format!("{}:{}", prefix, renamed_label)
-      } else {
-        renamed_label.to_string()
-      };
+      let label_name = build_label_name(&field, &field_attrs);
 
       match get_field_type(field) {
         Some(FieldType::FieldTypeString)
@@ -472,4 +456,18 @@ pub fn serialize(
       }
     }
   }
+}
+
+fn build_label_name(field: &syn::Field, field_attrs: &YaSerdeAttribute) -> String {
+  format!(
+    "{}{}",
+    field_attrs
+      .prefix
+      .clone()
+      .map_or("".to_string(), |prefix| prefix + ":"),
+    field_attrs
+      .rename
+      .clone()
+      .unwrap_or_else(|| field.ident.as_ref().unwrap().to_string())
+  )
 }


### PR DESCRIPTION
Hey! A small fix here.

There were compilation errors when I tried to (de)serialize XML with dots in element names:

```xml
<?xml version="1.0" encoding="utf-8"?>
<root xmlns:ns="http://www.sample.com/ns/domain">
    <with.dots>value</with.dots>
</root>
```

Macro generated idents like `__Visitor_with.dots` which are invalid in Rust. The fix is straightforward, I've basically used `replace(".", "_")` where needed.