### PR TITLE
Feature flatten (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library will support XML de/ser-ializing with all specific features.
 
 - [x] **attribute**: this field is defined as an attribute
 - [x] **default**: defines the default function to init the field
-- [ ] **flatten**: Flatten the contents of the field
+- [x] **flatten**: Flatten the contents of the field
 - [x] **namespace**: defines the namespace of the field
 - [x] **rename**: be able to rename a field
 - [x] **root**: rename the based element. Used only at the XML root.

--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -647,3 +647,89 @@ fn de_custom() {
     }
   );
 }
+
+#[test]
+fn de_flatten() {
+  #[derive(Default, PartialEq, Debug, YaDeserialize)]
+  struct DateTime {
+    #[yaserde(flatten)]
+    date: Date,
+    time: String,
+    #[yaserde(flatten)]
+    kind: DateKind,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaDeserialize)]
+  struct Date {
+    year: i32,
+    month: i32,
+    day: i32,
+    #[yaserde(flatten)]
+    extra: Extra,
+    #[yaserde(flatten)]
+    optional_extra: Option<OptionalExtra>,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaDeserialize)]
+  pub struct Extra {
+    week: i32,
+    century: i32,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaDeserialize)]
+  pub struct OptionalExtra {
+    lunar_day: i32,
+  }
+
+  #[derive(PartialEq, Debug, YaDeserialize)]
+  pub enum DateKind {
+    #[yaserde(rename = "holidays")]
+    Holidays(Vec<String>),
+    #[yaserde(rename = "working")]
+    Working,
+  }
+
+  impl Default for DateKind {
+    fn default() -> Self {
+      DateKind::Working
+    }
+  };
+
+  let content = r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <DateTime>
+      <year>2020</year>
+      <month>1</month>
+      <day>1</day>
+      <week>1</week>
+      <century>21</century>
+      <lunar_day>1</lunar_day>
+      <time>10:40:03</time>
+      <holidays>New Year's Day</holidays>
+      <holidays>Novy God Day</holidays>
+      <holidays>Polar Bear Swim Day</holidays>
+    </DateTime>
+  "#;
+  convert_and_validate!(
+    content,
+    DateTime,
+    DateTime {
+      date: Date {
+        year: 2020,
+        month: 1,
+        day: 1,
+        extra: Extra {
+          week: 1,
+          century: 21,
+        },
+        optional_extra: Some(OptionalExtra { lunar_day: 1 }),
+      },
+      time: "10:40:03".to_string(),
+      kind: DateKind::Holidays(vec![
+        "New Year's Day".into(),
+        "Novy God Day".into(),
+        "Polar Bear Swim Day".into()
+      ])
+    }
+  );
+}

--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -11,7 +11,15 @@ use yaserde::YaSerialize;
 macro_rules! convert_and_validate {
   ($model: expr, $content: expr) => {
     let data: Result<String, String> = to_string(&$model);
-    assert_eq!(data, Ok(String::from($content)));
+    assert_eq!(
+      data,
+      Ok(
+        String::from($content)
+          .split("\n")
+          .map(|s| s.trim())
+          .collect::<String>()
+      )
+    );
   };
 }
 
@@ -487,5 +495,89 @@ fn ser_custom() {
     day: Day { value: 5 },
   };
   let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Date><Year>2020</Year><Month>1</Month><DoubleDay>10</DoubleDay></Date>";
+  convert_and_validate!(model, content);
+}
+
+#[test]
+fn ser_flatten() {
+  #[derive(Default, PartialEq, Debug, YaSerialize)]
+  struct DateTime {
+    #[yaserde(flatten)]
+    date: Date,
+    time: String,
+    #[yaserde(flatten)]
+    kind: DateKind,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaSerialize)]
+  struct Date {
+    year: i32,
+    month: i32,
+    day: i32,
+    #[yaserde(flatten)]
+    extra: Extra,
+    #[yaserde(flatten)]
+    optional_extra: Option<OptionalExtra>,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaSerialize)]
+  pub struct Extra {
+    week: i32,
+    century: i32,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaSerialize)]
+  pub struct OptionalExtra {
+    lunar_day: i32,
+  }
+
+  #[derive(PartialEq, Debug, YaSerialize)]
+  pub enum DateKind {
+    #[yaserde(rename = "holidays")]
+    Holidays(Vec<String>),
+    #[yaserde(rename = "working")]
+    Working,
+  }
+
+  impl Default for DateKind {
+    fn default() -> Self {
+      DateKind::Working
+    }
+  };
+
+  let model = DateTime {
+    date: Date {
+      year: 2020,
+      month: 1,
+      day: 1,
+      extra: Extra {
+        week: 1,
+        century: 21,
+      },
+      optional_extra: Some(OptionalExtra { lunar_day: 1 }),
+    },
+    time: "10:40:03".to_string(),
+    kind: DateKind::Holidays(vec![
+      "New Year's Day".into(),
+      "Novy God Day".into(),
+      "Polar Bear Swim Day".into(),
+    ]),
+  };
+
+  let content = r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <DateTime>
+      <year>2020</year>
+      <month>1</month>
+      <day>1</day>
+      <week>1</week>
+      <century>21</century>
+      <lunar_day>1</lunar_day>
+      <time>10:40:03</time>
+      <holidays>New Year's Day</holidays>
+      <holidays>Novy God Day</holidays>
+      <holidays>Polar Bear Swim Day</holidays>
+    </DateTime>"#;
+
   convert_and_validate!(model, content);
 }

--- a/yaserde_derive/src/attribute.rs
+++ b/yaserde_derive/src/attribute.rs
@@ -13,6 +13,7 @@ pub struct YaSerdeAttribute {
   pub namespaces: BTreeMap<String, String>,
   pub attribute: bool,
   pub text: bool,
+  pub flatten: bool,
 }
 
 fn get_value(iter: &mut IntoIter) -> Option<String> {
@@ -38,6 +39,7 @@ impl YaSerdeAttribute {
     let mut root = None;
     let mut default = None;
     let mut text = false;
+    let mut flatten = false;
 
     for attr in attrs.iter() {
       let mut attr_iter = attr.clone().tokens.into_iter();
@@ -78,6 +80,9 @@ impl YaSerdeAttribute {
                   "text" => {
                     text = true;
                   }
+                  "flatten" => {
+                    flatten = true;
+                  }
                   _ => {}
                 }
               }
@@ -95,6 +100,7 @@ impl YaSerdeAttribute {
       root,
       default,
       text,
+      flatten,
     }
   }
 }
@@ -113,6 +119,7 @@ fn parse_empty_attributes() {
       namespaces: BTreeMap::new(),
       attribute: false,
       text: false,
+      flatten: false,
     },
     attrs
   );
@@ -160,6 +167,7 @@ fn parse_attributes() {
       namespaces: BTreeMap::new(),
       attribute: true,
       text: false,
+      flatten: false,
     },
     attrs
   );


### PR DESCRIPTION
Hey! I've added support for `flatten`. It is now possible to mark `struct`, `optional struct` and `enum` fields to be `flatten`ed:

```rust
  #[derive(Default, PartialEq, Debug, YaDeserialize)]
  struct DateTime {
    #[yaserde(flatten)]
    date: Date,
    time: String,
    #[yaserde(flatten)]
    kind: DateKind,
  }

  #[derive(Default, PartialEq, Debug, YaDeserialize)]
  struct Date {
    year: i32,
    month: i32,
    day: i32,
    #[yaserde(flatten)]
    extra: Extra,
    #[yaserde(flatten)]
    optional_extra: Option<OptionalExtra>,
  }

  #[derive(Default, PartialEq, Debug, YaDeserialize)]
  pub struct Extra {
    week: i32,
    century: i32,
  }

  #[derive(Default, PartialEq, Debug, YaDeserialize)]
  pub struct OptionalExtra {
    lunar_day: i32,
  }

  #[derive(PartialEq, Debug, YaDeserialize)]
  pub enum DateKind {
    #[yaserde(rename = "holidays")]
    Holidays(Vec<String>),
    #[yaserde(rename = "working")]
    Working,
  }
```

And corresponding XML:

```xml
<?xml version="1.0" encoding="utf-8"?>
<DateTime>
      <year>2020</year>
      <month>1</month>
      <day>1</day>
      <week>1</week>
      <century>21</century>
      <lunar_day>1</lunar_day>
      <time>10:40:03</time>
      <holidays>New Year's Day</holidays>
      <holidays>Novy God Day</holidays>
      <holidays>Polar Bear Swim Day</holidays>
</DateTime>
```
