### PR TITLE
Add support for Option<struct> in 'attribute' fields

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -173,6 +173,53 @@ fn de_attributes() {
 }
 
 #[test]
+fn de_attributes_complex() {
+  mod other_mod {
+    use super::*;
+
+    #[derive(YaDeserialize, PartialEq, Debug)]
+    pub enum AttrEnum {
+      #[yaserde(rename = "variant 1")]
+      Variant1,
+      #[yaserde(rename = "variant 2")]
+      Variant2,
+    }
+
+    impl Default for AttrEnum {
+      fn default() -> AttrEnum {
+        AttrEnum::Variant1
+      }
+    }
+  }
+
+  #[derive(Default, YaDeserialize, PartialEq, Debug)]
+  pub struct Struct {
+    #[yaserde(attribute)]
+    attr_option_string: Option<std::string::String>,
+    #[yaserde(attribute)]
+    attr_option_enum: Option<other_mod::AttrEnum>,
+  }
+
+  convert_and_validate!(
+    r#"<Struct />"#,
+    Struct,
+    Struct {
+      attr_option_string: None,
+      attr_option_enum: None
+    }
+  );
+
+  convert_and_validate!(
+    r#"<Struct attr_option_string="some value" attr_option_enum="variant 2" />"#,
+    Struct,
+    Struct {
+      attr_option_string: Some("some value".to_string()),
+      attr_option_enum: Some(other_mod::AttrEnum::Variant2)
+    }
+  );
+}
+
+#[test]
 fn de_rename() {
   #[derive(YaDeserialize, PartialEq, Debug)]
   #[yaserde(root = "base")]

--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -125,6 +125,66 @@ fn se_attributes() {
 }
 
 #[test]
+fn se_attributes_complex() {
+  mod other_mod {
+    use super::*;
+
+    #[derive(YaSerialize, PartialEq, Debug)]
+    pub enum AttrEnum {
+      #[yaserde(rename = "variant 1")]
+      Variant1,
+      #[yaserde(rename = "variant 2")]
+      Variant2,
+    }
+
+    impl Default for AttrEnum {
+      fn default() -> AttrEnum {
+        AttrEnum::Variant1
+      }
+    }
+  }
+
+  #[derive(YaSerialize, PartialEq, Debug)]
+  pub struct Struct {
+    #[yaserde(attribute)]
+    attr_option_string: Option<std::string::String>,
+    #[yaserde(attribute)]
+    attr_option_enum: Option<other_mod::AttrEnum>,
+  }
+
+  impl Default for Struct {
+    fn default() -> Struct {
+      Struct {
+        attr_option_string: None,
+        attr_option_enum: None,
+      }
+    }
+  }
+
+  convert_and_validate!(
+    Struct {
+      attr_option_string: None,
+      attr_option_enum: None,
+    },
+    r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <Struct />
+    "#
+  );
+
+  convert_and_validate!(
+    Struct {
+      attr_option_string: Some("some value".to_string()),
+      attr_option_enum: Some(other_mod::AttrEnum::Variant2),
+    },
+    r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <Struct attr_option_string="some value" attr_option_enum="variant 2" />
+    "#
+  );
+}
+
+#[test]
 fn ser_rename() {
   #[derive(YaSerialize, PartialEq, Debug)]
   #[yaserde(root = "base")]

--- a/yaserde_derive/src/field_type.rs
+++ b/yaserde_derive/src/field_type.rs
@@ -37,10 +37,10 @@ impl FieldType {
         "f32" => Some(FieldType::FieldTypeF32),
         "f64" => Some(FieldType::FieldTypeF64),
         "Option" => get_sub_type(t).map(|data_type| FieldType::FieldTypeOption {
-          data_type: Box::new(FieldType::from_ident(&syn::Path::from(data_type)).unwrap()),
+          data_type: Box::new(FieldType::from_ident(&data_type).unwrap()),
         }),
         "Vec" => get_sub_type(t).map(|data_type| FieldType::FieldTypeVec {
-          data_type: Box::new(FieldType::from_ident(&syn::Path::from(data_type)).unwrap()),
+          data_type: Box::new(FieldType::from_ident(&data_type).unwrap()),
         }),
         _ => Some(FieldType::FieldTypeStruct {
           struct_name: path.clone(),
@@ -58,14 +58,12 @@ pub fn get_field_type(field: &syn::Field) -> Option<FieldType> {
   }
 }
 
-fn get_sub_type(t: &syn::PathSegment) -> Option<syn::PathSegment> {
+fn get_sub_type(t: &syn::PathSegment) -> Option<syn::Path> {
   if let syn::PathArguments::AngleBracketed(ref args) = t.arguments {
     if let Some(tt) = args.args.first() {
       if let syn::GenericArgument::Type(ref argument) = *tt {
-        if let Path(ref path2) = *argument {
-          if let Some(ttt) = path2.path.segments.first() {
-            return Some(ttt.clone());
-          }
+        if let Path(ref path) = *argument {
+          return Some(path.path.clone());
         }
       }
     }


### PR DESCRIPTION
Hey @MarcAntoine-Arnaud !

Now it is possible to use `Option<struct>` or `Option<enum>` in fields marked as `attribute`:

```rust
  #[derive(YaDeserialize, YaSerialize, PartialEq, Debug)]
  enum AttrEnum {
    Variant1,
    Variant2,
  }

  #[derive(YaDeserialize, YaSerialize, Default, PartialEq, Debug)]
  struct Struct {
    #[yaserde(attribute)]
    attr_option_enum: Option<AttrEnum>,
  }
```

Corresponding XML can be like:

```xml
<?xml version="1.0" encoding="utf-8"?>
<Struct attr_option_enum="Variant2" />
```