### PR TITLE
Add skipping of unrecognized elements (fixes #12)

### DIFF
--- a/yaserde/src/de/mod.rs
+++ b/yaserde/src/de/mod.rs
@@ -88,6 +88,16 @@ impl<'de, R: Read> Deserializer<R> {
     Ok(next_event)
   }
 
+  pub fn skip_element(&mut self, mut cb: impl FnMut(&XmlEvent)) -> Result<(), String> {
+    let depth = self.depth;
+
+    while self.depth >= depth {
+      cb(&self.next_event()?);
+    }
+
+    Ok(())
+  }
+
   pub fn set_map_value(&mut self) {
     self.is_map_value = true;
   }

--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -780,3 +780,45 @@ fn de_flatten() {
     }
   );
 }
+
+#[test]
+fn de_subitem_issue_12() {
+  #[derive(Default, PartialEq, Debug, YaDeserialize)]
+  pub struct Struct {
+    id: i32,
+  }
+
+  convert_and_validate!(
+    r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <Struct>
+      <id>54</id>
+      <SubStruct>
+        <id>86</id>
+      </SubStruct>
+    </Struct>
+    "#,
+    Struct,
+    Struct { id: 54 }
+  );
+}
+
+#[test]
+fn de_subitem_issue_12_attributes() {
+  #[derive(Default, PartialEq, Debug, YaDeserialize)]
+  pub struct Struct {
+    #[yaserde(attribute)]
+    id: i32,
+  }
+
+  convert_and_validate!(
+    r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <Struct id="54">
+      <SubStruct id="86" />
+    </Struct>
+    "#,
+    Struct,
+    Struct { id: 54 }
+  );
+}


### PR DESCRIPTION
This should fix #12 
The idea is to skip entire element with all its children when element is not matched against known field names.