### PR TITLE
Fix (de)serialization for elements with nested namespaces

### DIFF
--- a/yaserde/src/de/mod.rs
+++ b/yaserde/src/de/mod.rs
@@ -98,6 +98,10 @@ impl<'de, R: Read> Deserializer<R> {
     Ok(())
   }
 
+  pub fn depth(&self) -> usize {
+    self.depth
+  }
+
   pub fn set_map_value(&mut self) {
     self.is_map_value = true;
   }

--- a/yaserde/tests/der_namespace.rs
+++ b/yaserde/tests/der_namespace.rs
@@ -90,6 +90,41 @@ fn de_struct_namespace() {
 }
 
 #[test]
+fn de_struct_namespace_nested() {
+  #[derive(YaDeserialize, Default, PartialEq, Debug)]
+  #[yaserde(prefix = "nsa", namespace = "nsa: http://www.sample.com/ns/a")]
+  struct A {
+    #[yaserde(prefix = "nsa")]
+    alpha: i32,
+  }
+
+  #[derive(YaDeserialize, Default, PartialEq, Debug)]
+  #[yaserde(prefix = "nsb", namespace = "nsb: http://www.sample.com/ns/b")]
+  struct B {
+    // Note that name `nested` resides in `nsb` though it has a type from `nsa`
+    #[yaserde(prefix = "nsb")]
+    nested: A,
+  }
+
+  convert_and_validate!(
+    r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <nsb:B 
+        xmlns:nsa="http://www.sample.com/ns/a" 
+        xmlns:nsb="http://www.sample.com/ns/b">
+      <nsb:nested>
+        <nsa:alpha>32</nsa:alpha>
+      </nsb:nested>
+    </nsb:B>
+    "#,
+    B,
+    B {
+      nested: A { alpha: 32 }
+    }
+  );
+}
+
+#[test]
 fn de_enum_namespace() {
   #[derive(YaDeserialize, PartialEq, Debug)]
   #[yaserde(

--- a/yaserde/tests/se_namespace.rs
+++ b/yaserde/tests/se_namespace.rs
@@ -9,9 +9,17 @@ use yaserde::ser::to_string;
 use yaserde::YaSerialize;
 
 macro_rules! convert_and_validate {
-  ($model:expr, $content:expr) => {
+  ($model: expr, $content: expr) => {
     let data: Result<String, String> = to_string(&$model);
-    assert_eq!(data, Ok(String::from($content)));
+    assert_eq!(
+      data,
+      Ok(
+        String::from($content)
+          .split("\n")
+          .map(|s| s.trim())
+          .collect::<String>()
+      )
+    );
   };
 }
 
@@ -151,4 +159,36 @@ fn ser_struct_default_namespace() {
 
   let content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><tt xmlns=\"http://www.w3.org/ns/ttml\" xmlns:ttm=\"http://www.w3.org/ns/ttml#metadata\"><item>something</item></tt>";
   convert_and_validate!(model, content);
+}
+
+#[test]
+fn de_struct_namespace_nested() {
+  #[derive(YaSerialize, Default, PartialEq, Debug)]
+  #[yaserde(prefix = "nsa", namespace = "nsa: http://www.sample.com/ns/a")]
+  struct A {
+    #[yaserde(prefix = "nsa")]
+    alpha: i32,
+  }
+
+  #[derive(YaSerialize, Default, PartialEq, Debug)]
+  #[yaserde(prefix = "nsb", namespace = "nsb: http://www.sample.com/ns/b")]
+  struct B {
+    // Note that name `nested` resides in `nsb` though it has a type from `nsa`
+    #[yaserde(prefix = "nsb")]
+    nested: A,
+  }
+
+  convert_and_validate!(
+    B {
+      nested: A { alpha: 32 }
+    },
+    r#"
+    <?xml version="1.0" encoding="utf-8"?>
+    <nsb:B xmlns:nsb="http://www.sample.com/ns/b">
+      <nsb:nested xmlns:nsa="http://www.sample.com/ns/a">
+        <nsa:alpha>32</nsa:alpha>
+      </nsb:nested>
+    </nsb:B>
+    "#
+  );
 }

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -17,9 +17,8 @@ pub fn parse(
   let namespaces_matches: TokenStream = namespaces
     .iter()
     .map(|(p, ns)| {
-      let str_ns = ns.as_str();
-      if *prefix == Some(p.to_string()) {
-        Some(quote!(#str_ns => {}))
+      if prefix.as_ref() == Some(p) {
+        Some(quote!(#ns => {}))
       } else {
         None
       }
@@ -382,15 +381,17 @@ pub fn parse(
           };
         debug!("Struct: start to parse {:?}", named_element);
 
-        if let Some(ref namespace) = struct_namespace {
-          match namespace.as_str() {
-            #namespaces_matches
-            bad_ns => {
-              let msg = format!("bad namespace for {}, found {}", named_element, bad_ns);
-              return Err(msg);
+        if reader.depth() == 0 {
+          if let Some(ref namespace) = struct_namespace {
+            match namespace.as_str() {
+              #namespaces_matches
+              bad_ns => {
+                let msg = format!("bad namespace for {}, found {}", named_element, bad_ns);
+                return Err(msg);
+              }
             }
           }
-        };
+        }
 
         #variables
         #field_visitors

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -405,15 +405,10 @@ pub fn serialize(
         let skip = writer.skip_start_end();
 
         if !skip {
-          if let Some(label) = writer.get_start_event_name() {
-            let struct_start_event = XmlEvent::start_element(label.as_ref());
-            #build_attributes
-            let _ret = writer.write(struct_start_event);
-          } else {
-            let struct_start_event = XmlEvent::start_element(#root)#add_namespaces;
-            #build_attributes
-            let _ret = writer.write(struct_start_event);
-          }
+          let label = writer.get_start_event_name().unwrap_or_else(|| #root.to_string());
+          let struct_start_event = XmlEvent::start_element(label.as_ref())#add_namespaces;
+          #build_attributes
+          let _ret = writer.write(struct_start_event);
         }
 
         #struct_inspector


### PR DESCRIPTION
Hey! 

Here is a tricky case. Consider you have struct `A` in namespace `nsa`:

```rust
  #[derive(YaSerialize, Default, PartialEq, Debug)]
  #[yaserde(prefix = "nsa", namespace = "nsa: http://www.sample.com/ns/a")]
  struct A {
    #[yaserde(prefix = "nsa")]
    alpha: i32,
  }
```

And you want to nest it into another struct `B` that is declared in namespace `nsb`:
```rust
  #[derive(YaSerialize, Default, PartialEq, Debug)]
  #[yaserde(prefix = "nsb", namespace = "nsb: http://www.sample.com/ns/b")]
  struct B {
    #[yaserde(prefix = "nsb")]
    nested: A,
  }
```

The problem is that now yaserde tries to check `nested: A` against both namespaces:
- root namespace `nsb`
- imported namespace `nsa`

but namespaces are different and it fails.


### More details

I've made example xsd's to prove that `nested` should have prefix `nsb`:

##### `a.xsd`
```xml
<?xml version="1.0" ?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           targetNamespace="http://example.com/a"
           elementFormDefault="qualified">

    <xs:complexType name="A">
        <xs:sequence>
            <xs:element name="alpha" type="xs:int"/>
        </xs:sequence>
    </xs:complexType>

</xs:schema>
```

##### `b.xsd`
```xml
<?xml version="1.0" ?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:nsa="http://example.com/a"
           xmlns:nsb="http://example.com/b"
           targetNamespace="http://example.com/b"
           elementFormDefault="qualified">

    <xs:import namespace="http://example.com/a" schemaLocation="a.xsd"/>

    <xs:complexType name="B">
        <xs:sequence>
            <xs:element name="nested" type="nsa:A"/>
        </xs:sequence>
    </xs:complexType>

    <xs:element name="B" type="nsb:B"/>
</xs:schema>
```

and `xsd2inst b.xsd -name B` gives output:

```xml
<b:B xmlns:b="http://example.com/b" xmlns:a="http://example.com/a">
  <b:nested>
    <a:alpha>3</a:alpha>
  </b:nested>
</b:B>
```
so, please note that `nested` here has prefix `b`.

### Solution
There are now separate namespace checks for struct and for the fields. I've changed it to check struct namespace only when it is a schema root (i.e. `reader.depth() == 0`). The rest of elements are checked against field namespaces.