### PR TITLE
Added explicit use log::debug

### DIFF
--- a/yaserde_derive/src/de/expand_enum.rs
+++ b/yaserde_derive/src/de/expand_enum.rs
@@ -25,6 +25,7 @@ pub fn parse(
     use yaserde::Visitor;
     #[allow(unknown_lints, unused_imports)]
     use std::str::FromStr;
+    use log::debug;
 
     impl YaDeserialize for #name {
       #[allow(unused_variables)]

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -369,6 +369,7 @@ pub fn parse(
     use yaserde::Visitor;
     #[allow(unknown_lints, unused_imports)]
     use std::str::FromStr;
+    use log::debug;
 
     impl YaDeserialize for #name {
       #[allow(unused_variables)]


### PR DESCRIPTION
It is annoying and not intuitive if the user has to add a `use log::debug` in his code when he doesn't know why and the library could actually do it itself. So this should improve the user experience! :)