### PR TITLE
Enforce std String in macros to avoid collisions

### DIFF
--- a/yaserde/src/lib.rs
+++ b/yaserde/src/lib.rs
@@ -19,12 +19,13 @@ pub mod ser;
 
 /// A **data structure** that can be deserialized from any data format supported by YaSerDe.
 pub trait YaDeserialize: Sized {
-  fn deserialize<R: Read>(reader: &mut de::Deserializer<R>) -> Result<Self, String>;
+  fn deserialize<R: Read>(reader: &mut de::Deserializer<R>) -> Result<Self, std::string::String>;
 }
 
 /// A **data structure** that can be serialized into any data format supported by YaSerDe.
 pub trait YaSerialize: Sized {
-  fn serialize<W: Write>(&self, writer: &mut ser::Serializer<W>) -> Result<(), String>;
+  fn serialize<W: Write>(&self, writer: &mut ser::Serializer<W>)
+    -> Result<(), std::string::String>;
 
   fn serialize_attributes(
     &self,
@@ -35,7 +36,7 @@ pub trait YaSerialize: Sized {
       Vec<xml::attribute::OwnedAttribute>,
       xml::namespace::Namespace,
     ),
-    String,
+    std::string::String,
   >;
 }
 
@@ -44,51 +45,51 @@ pub trait Visitor<'de>: Sized {
   /// The value produced by this visitor.
   type Value;
 
-  fn visit_bool(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_bool(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected bool {:?}", v))
   }
 
-  fn visit_i8(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_i8(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected i8 {:?}", v))
   }
 
-  fn visit_u8(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_u8(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected u8 {:?}", v))
   }
 
-  fn visit_i16(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_i16(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected i16 {:?}", v))
   }
 
-  fn visit_u16(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_u16(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected u16 {:?}", v))
   }
 
-  fn visit_i32(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_i32(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected i32 {:?}", v))
   }
 
-  fn visit_u32(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_u32(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected u32 {:?}", v))
   }
 
-  fn visit_i64(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_i64(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected i64 {:?}", v))
   }
 
-  fn visit_u64(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_u64(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected u64 {:?}", v))
   }
 
-  fn visit_f32(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_f32(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected f32 {:?}", v))
   }
 
-  fn visit_f64(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_f64(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected f64 {:?}", v))
   }
 
-  fn visit_str(self, v: &str) -> Result<Self::Value, String> {
+  fn visit_str(self, v: &str) -> Result<Self::Value, std::string::String> {
     Err(format!("Unexpected str {:?}", v))
   }
 }
@@ -96,7 +97,10 @@ pub trait Visitor<'de>: Sized {
 macro_rules! serialize_type {
   ($type:ty) => {
     impl YaSerialize for $type {
-      fn serialize<W: Write>(&self, writer: &mut ser::Serializer<W>) -> Result<(), String> {
+      fn serialize<W: Write>(
+        &self,
+        writer: &mut ser::Serializer<W>,
+      ) -> Result<(), std::string::String> {
         let content = format!("{}", self);
         let event = XmlEvent::characters(&content);
         let _ret = writer.write(event);
@@ -112,7 +116,7 @@ macro_rules! serialize_type {
           Vec<xml::attribute::OwnedAttribute>,
           xml::namespace::Namespace,
         ),
-        String,
+        std::string::String,
       > {
         Ok((attributes, namespace))
       }
@@ -178,9 +182,9 @@ mod testing {
       let model = Data { item: $value };
 
       let content = if let Some(str_value) = $content {
-        String::from("<data><item>") + str_value + "</item></data>"
+        std::string::String::from("<data><item>") + str_value + "</item></data>"
       } else {
-        String::from("<data />")
+        std::string::String::from("<data />")
       };
 
       serialize_and_validate!(model, content);
@@ -214,7 +218,7 @@ mod testing {
   macro_rules! deserialize_and_validate {
     ($content: expr, $model: expr, $struct: tt) => {
       log::debug!("deserialize_and_validate @ {}:{}", file!(), line!());
-      let loaded: Result<$struct, String> = yaserde::de::from_str($content);
+      let loaded: Result<$struct, std::string::String> = yaserde::de::from_str($content);
       assert_eq!(loaded, Ok($model));
     };
   }
@@ -223,16 +227,17 @@ mod testing {
   macro_rules! serialize_and_validate {
     ($model: expr, $content: expr) => {
       log::debug!("serialize_and_validate @ {}:{}", file!(), line!());
-      let data: Result<String, String> = yaserde::ser::to_string(&$model);
+      let data: Result<std::string::String, std::string::String> = yaserde::ser::to_string(&$model);
 
-      let content = String::from(r#"<?xml version="1.0" encoding="utf-8"?>"#) + &$content;
+      let content =
+        std::string::String::from(r#"<?xml version="1.0" encoding="utf-8"?>"#) + &$content;
       assert_eq!(
         data,
         Ok(
-          String::from(content)
+          std::string::String::from(content)
             .split("\n")
             .map(|s| s.trim())
-            .collect::<String>()
+            .collect::<std::string::String>()
         )
       );
     };

--- a/yaserde/src/ser/mod.rs
+++ b/yaserde/src/ser/mod.rs
@@ -11,14 +11,14 @@ pub fn to_string<T: YaSerialize>(model: &T) -> Result<String, String> {
   let buf = Cursor::new(Vec::new());
   let cursor = serialize_with_writer(model, buf, &Config::default())?;
   let data = str::from_utf8(cursor.get_ref()).expect("Found invalid UTF-8");
-  Ok(String::from(data))
+  Ok(std::string::String::from(data))
 }
 
 pub fn to_string_with_config<T: YaSerialize>(model: &T, config: &Config) -> Result<String, String> {
   let buf = Cursor::new(Vec::new());
   let cursor = serialize_with_writer(model, buf, config)?;
   let data = str::from_utf8(cursor.get_ref()).expect("Found invalid UTF-8");
-  Ok(String::from(data))
+  Ok(std::string::String::from(data))
 }
 
 pub fn serialize_with_writer<W: Write, T: YaSerialize>(
@@ -37,7 +37,7 @@ pub fn to_string_content<T: YaSerialize>(model: &T) -> Result<String, String> {
   let buf = Cursor::new(Vec::new());
   let cursor = serialize_with_writer_content(model, buf)?;
   let data = str::from_utf8(cursor.get_ref()).expect("Found invalid UTF-8");
-  Ok(String::from(data))
+  Ok(std::string::String::from(data))
 }
 
 pub fn serialize_with_writer_content<W: Write, T: YaSerialize>(

--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -15,7 +15,7 @@ fn init() {
 macro_rules! convert_and_validate {
   ($content: expr, $struct: tt, $model: expr) => {
     debug!("convert_and_validate @ {}:{}", file!(), line!());
-    let loaded: Result<$struct, String> = from_str($content);
+    let loaded: Result<$struct, std::string::String> = from_str($content);
     assert_eq!(loaded, Ok($model));
   };
 }
@@ -785,7 +785,9 @@ fn de_custom() {
   }
 
   impl YaDeserialize for Day {
-    fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+    fn deserialize<R: Read>(
+      reader: &mut yaserde::de::Deserializer<R>,
+    ) -> Result<Self, std::string::String> {
       use std::str::FromStr;
 
       if let xml::reader::XmlEvent::StartElement { name, .. } = reader.peek()?.to_owned() {

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -254,7 +254,7 @@ impl From<&syn::PathSegment> for Field {
 impl Into<proc_macro2::TokenStream> for Field {
   fn into(self) -> proc_macro2::TokenStream {
     match self {
-      Field::FieldString => quote! {String},
+      Field::FieldString => quote! {std::string::String},
       Field::FieldBool => quote! {bool},
       Field::FieldI8 => quote! {i8},
       Field::FieldU8 => quote! {u8},
@@ -272,7 +272,7 @@ impl Into<proc_macro2::TokenStream> for Field {
 }
 
 impl Into<String> for &Field {
-  fn into(self) -> String {
+  fn into(self) -> std::string::String {
     match self {
       Field::FieldString => "str".to_string(),
       Field::FieldBool => "bool".to_string(),
@@ -293,7 +293,7 @@ impl Into<String> for &Field {
 
 impl fmt::Display for Field {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let string_representation: String = self.into();
+    let string_representation: std::string::String = self.into();
     write!(f, "{}", string_representation)
   }
 }

--- a/yaserde_derive/src/de/expand_enum.rs
+++ b/yaserde_derive/src/de/expand_enum.rs
@@ -33,12 +33,12 @@ pub fn parse(
 
     impl YaDeserialize for #name {
       #[allow(unused_variables)]
-      fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+      fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, std::string::String> {
         let (named_element, enum_namespace) =
           if let XmlEvent::StartElement{name, ..} = reader.peek()?.to_owned() {
             (name.local_name.to_owned(), name.namespace.clone())
           } else {
-            (String::from(#root), None)
+            (std::string::String::from(#root), None)
           };
 
         let start_depth = reader.depth();
@@ -161,7 +161,7 @@ fn build_unnamed_field_visitors(fields: &syn::FieldsUnnamed) -> TokenStream {
             impl<'de> Visitor<'de> for #visitor_label {
               type Value = #field_type;
 
-              fn #visitor(self, v: &str) -> Result<Self::Value, String> {
+              fn #visitor(self, v: &str) -> Result<Self::Value,  std::string::String> {
                 #fn_body
               }
             }
@@ -181,7 +181,7 @@ fn build_unnamed_field_visitors(fields: &syn::FieldsUnnamed) -> TokenStream {
 
       match field.get_type() {
         Field::FieldStruct { struct_name } => {
-          let struct_id: String = struct_name
+          let struct_id: std::string::String = struct_name
             .segments
             .iter()
             .map(|s| s.ident.to_string())
@@ -192,7 +192,7 @@ fn build_unnamed_field_visitors(fields: &syn::FieldsUnnamed) -> TokenStream {
             &quote! { #struct_name },
             &quote! {
               let content = "<".to_string() + #struct_id + ">" + v + "</" + #struct_id + ">";
-              let value : Result<#struct_name, String> = yaserde::de::from_str(&content);
+              let value : Result<#struct_name, std::string::String> = yaserde::de::from_str(&content);
               value
             },
           )
@@ -267,7 +267,7 @@ fn build_unnamed_visitor_calls(
         match enum_value {
           Some(ref mut v) => match v {
             #variant_name(ref mut v) => v.push(value),
-            _ => return Err(String::from("Got sequence of different types"))
+            _ => return Err(std::string::String::from("Got sequence of different types"))
           }
           None => {
             enum_value = Some(#variant_name(vec![value]));

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -57,7 +57,7 @@ pub fn parse(
     .map(|field| YaSerdeField::new(field.clone()))
     .map(|field| {
       let struct_visitor = |struct_name: syn::Path| {
-        let struct_id: String = struct_name
+        let struct_id: std::string::String = struct_name
           .segments
           .iter()
           .map(|s| s.ident.to_string())
@@ -71,9 +71,9 @@ pub fn parse(
           impl<'de> Visitor<'de> for #visitor_label {
             type Value = #struct_name;
 
-            fn visit_str(self, v: &str) -> Result<Self::Value, String> {
+            fn visit_str(self, v: &str) -> Result<Self::Value, std::string::String> {
               let content = "<".to_string() + #struct_id + ">" + v + "</" + #struct_id + ">";
-              let value : Result<#struct_name, String> = yaserde::de::from_str(&content);
+              let value : Result<#struct_name, std::string::String> = yaserde::de::from_str(&content);
               value
             }
           }
@@ -91,7 +91,7 @@ pub fn parse(
           impl<'de> Visitor<'de> for #visitor_label {
             type Value = #field_type;
 
-            fn #visitor(self, v: &str) -> Result<Self::Value, String> {
+            fn #visitor(self, v: &str) -> Result<Self::Value, std::string::String> {
               Ok(#field_type::from_str(v).unwrap())
             }
           }
@@ -315,12 +315,12 @@ pub fn parse(
 
     impl YaDeserialize for #name {
       #[allow(unused_variables)]
-      fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
+      fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, std::string::String> {
         let (named_element, struct_namespace) =
           if let XmlEvent::StartElement{name, ..} = reader.peek()?.to_owned() {
             (name.local_name.to_owned(), name.namespace.clone())
           } else {
-            (String::from(#root), None)
+            (std::string::String::from(#root), None)
           };
         let start_depth = reader.depth();
         debug!("Struct {} @ {}: start to parse {:?}", stringify!(#name), start_depth,
@@ -476,7 +476,7 @@ fn build_code_for_unused_xml_events(
     }),
     Some(quote! {
       if writer.is_some() {
-        let unused_xml_elements = String::from_utf8(buf).unwrap();
+        let unused_xml_elements = std::string::String::from_utf8(buf).unwrap();
         #call_flatten_visitors
       }
     }),

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -62,7 +62,7 @@ pub fn serialize(
             | Field::FieldU64
             | Field::FieldF32
             | Field::FieldF64 => field.ser_wrap_default_attribute(
-              Some(quote!(self.#label.map_or_else(|| String::new(), |v| v.to_string()))),
+              Some(quote!(self.#label.map_or_else(|| std::string::String::new(), |v| v.to_string()))),
               quote!({
                 if let Some(ref value) = self.#label {
                   struct_start_event.attr(#label_name, &yaserde_inner)
@@ -89,7 +89,7 @@ pub fn serialize(
             Field::FieldStruct { .. } => field.ser_wrap_default_attribute(
               Some(quote!(self.#label
                     .as_ref()
-                    .map_or_else(|| Ok(String::new()), |v| yaserde::ser::to_string_content(v))?)),
+                    .map_or_else(|| Ok(std::string::String::new()), |v| yaserde::ser::to_string_content(v))?)),
               quote!({
                 if let Some(ref yaserde_struct) = self.#label {
                   struct_start_event.attr(#label_name, &yaserde_inner)

--- a/yaserde_derive/src/ser/implement_serializer.rs
+++ b/yaserde_derive/src/ser/implement_serializer.rs
@@ -19,7 +19,7 @@ pub fn implement_serializer(
     impl YaSerialize for #name {
       #[allow(unused_variables)]
       fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>)
-        -> Result<(), String> {
+        -> Result<(), std::string::String> {
         let skip = writer.skip_start_end();
 
         if !#flatten && !skip {
@@ -61,7 +61,7 @@ pub fn implement_serializer(
         Ok(())
       }
 
-      fn serialize_attributes(&self, mut source_attributes: Vec<xml::attribute::OwnedAttribute>, mut source_namespace: xml::namespace::Namespace) -> Result<(Vec<xml::attribute::OwnedAttribute>, xml::namespace::Namespace), String> {
+      fn serialize_attributes(&self, mut source_attributes: Vec<xml::attribute::OwnedAttribute>, mut source_namespace: xml::namespace::Namespace) -> Result<(Vec<xml::attribute::OwnedAttribute>, xml::namespace::Namespace), std::string::String> {
         let mut child_attributes : Vec<xml::attribute::OwnedAttribute> = vec![];
         let mut child_attributes_namespace = xml::namespace::Namespace::empty();
 


### PR DESCRIPTION
"Autosar XML" and likely other XSDs I assume, define their own `STRING` complexType, this leads to naming collisions between std::string::String and the generated struct String in the generated macro output. This also affects other "Keywords" I can imagine there can be other cases e.g. `Vec` etc., so it might also make sense to figure out a more general way to avoid collisions for std types, e.g. prefix all generated types yaserde_gen_String or always use the generated types with an explicit prefix e.g. `yaserde_gen::String` or let people define this prefix `arxml::String`.

```
<xsd:complexType name="STRING">
```
is translated to:
```
pub struct String 
```

Failing compiler output:
```
#[derive(Debug, XmlSchema)]
   |                 ^^^^^^^^^
   |                 |
   |                 expected struct `String`, found struct `std::string::String`
   |                 expected due to this
   |
   = note: expected enum `std::result::Result<StandardNameEnumSimple, String>`
              found enum `std::result::Result<_, std::string::String>`
```