### PR TITLE
Avoid breaking keywords in labels.

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -55,6 +55,27 @@ fn de_basic() {
 }
 
 #[test]
+fn de_keyword() {
+  init();
+
+  #[derive(YaDeserialize, PartialEq, Debug)]
+  #[yaserde(root = "book")]
+  pub struct Book {
+    #[yaserde(attribute, rename = "ref")]
+    pub r#ref: String,
+  }
+
+  let content = "<book ref=\"978-1522968122\"></book>";
+  convert_and_validate!(
+    content,
+    Book,
+    Book {
+      r#ref: "978-1522968122".to_string()
+    }
+  );
+}
+
+#[test]
 fn de_dash_param() {
   init();
 

--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -327,6 +327,23 @@ fn ser_text_content_with_attributes() {
 }
 
 #[test]
+fn ser_keyword() {
+  #[derive(YaSerialize, PartialEq, Debug)]
+  #[yaserde(rename = "base")]
+  pub struct XmlStruct {
+    #[yaserde(attribute, rename = "ref")]
+    r#ref: String,
+  }
+
+  let model = XmlStruct {
+    r#ref: "978-1522968122".to_string(),
+  };
+
+  let content = "<base ref=\"978-1522968122\" />";
+  serialize_and_validate!(model, content);
+}
+
+#[test]
 fn ser_name_issue_21() {
   #[derive(YaSerialize, PartialEq, Debug)]
   #[yaserde(rename = "base")]

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -3,6 +3,7 @@ use heck::CamelCase;
 use proc_macro2::Span;
 use proc_macro2::{Ident, TokenStream};
 use std::fmt;
+use syn::ext::IdentExt;
 use syn::spanned::Spanned;
 use syn::Type::Path;
 
@@ -43,7 +44,7 @@ impl YaSerdeField {
       .syn_field
       .ident
       .clone()
-      .map(|ident| syn::Ident::new(&format!("__{}_value", ident.to_string()), ident.span()))
+      .map(|ident| syn::Ident::new(&format!("__{}_value", ident.unraw()), ident.span()))
   }
 
   pub fn renamed_label_without_namespace(&self) -> String {


### PR DESCRIPTION
Keywords such as `ref` previously lead to labels such as `__#ref__value`.
This should be `__ref__value`.