### PR TITLE
Prevent Yaserde from reading non #[yaserde(...)] attributes

### DIFF
--- a/yaserde_derive/src/common/attribute.rs
+++ b/yaserde_derive/src/common/attribute.rs
@@ -236,6 +236,55 @@ fn parse_attributes() {
 }
 
 #[test]
+fn only_parse_yaserde_attributes() {
+  use proc_macro2::{Span, TokenStream};
+  use std::str::FromStr;
+  use syn::punctuated::Punctuated;
+  use syn::token::Bracket;
+  use syn::token::Pound;
+  use syn::AttrStyle::Outer;
+  use syn::{Ident, Path, PathArguments, PathSegment};
+
+  let mut punctuated = Punctuated::new();
+  punctuated.push(PathSegment {
+    ident: Ident::new("serde", Span::call_site()),
+    arguments: PathArguments::None,
+  });
+
+  let attributes = vec![Attribute {
+    pound_token: Pound {
+      spans: [Span::call_site()],
+    },
+    style: Outer,
+    bracket_token: Bracket {
+      span: Span::call_site(),
+    },
+    path: Path {
+      leading_colon: None,
+      segments: punctuated,
+    },
+    tokens: TokenStream::from_str("(flatten)").unwrap(),
+  }];
+
+  let attrs = YaSerdeAttribute::parse(&attributes);
+
+  assert_eq!(
+    YaSerdeAttribute {
+      attribute: false,
+      default: None,
+      default_namespace: None,
+      flatten: false,
+      namespaces: BTreeMap::new(),
+      prefix: None,
+      rename: None,
+      skip_serializing_if: None,
+      text: false,
+    },
+    attrs
+  );
+}
+
+#[test]
 fn parse_attributes_with_values() {
   use proc_macro2::{Span, TokenStream};
   use std::str::FromStr;

--- a/yaserde_derive/src/common/attribute.rs
+++ b/yaserde_derive/src/common/attribute.rs
@@ -42,7 +42,7 @@ impl YaSerdeAttribute {
     let mut skip_serializing_if = None;
     let mut text = false;
 
-    for attr in attrs.iter() {
+    for attr in attrs.iter().filter(|a| a.path.is_ident("yaserde")) {
       let mut attr_iter = attr.clone().tokens.into_iter();
       if let Some(token) = attr_iter.next() {
         if let TokenTree::Group(group) = token {


### PR DESCRIPTION
Closes #101.

As I mentioned in that issue, I'm not sure if the previous behavior of reading any attribute that had the correct string inside was intended or not. Assuming that it wasn't, the solution is to just filter out all non-yaserde attributes. 

For reference, serde also filters out other attributes except for the serde attribute: https://github.com/serde-rs/serde/blob/b054ea41053ea4047882cc33970d2257cdfe04ac/serde_derive/src/internals/attr.rs#L1568