### PR TITLE
Use fully qualified method names to prevent collisions with serde derive macros

### DIFF
--- a/yaserde/src/de/mod.rs
+++ b/yaserde/src/de/mod.rs
@@ -11,7 +11,7 @@ pub fn from_str<T: YaDeserialize>(s: &str) -> Result<T, String> {
 }
 
 pub fn from_reader<R: Read, T: YaDeserialize>(reader: R) -> Result<T, String> {
-  T::deserialize(&mut Deserializer::new_from_reader(reader))
+  <T as YaDeserialize>::deserialize(&mut Deserializer::new_from_reader(reader))
 }
 
 pub struct Deserializer<R: Read> {

--- a/yaserde/src/ser/mod.rs
+++ b/yaserde/src/ser/mod.rs
@@ -27,7 +27,7 @@ pub fn serialize_with_writer<W: Write, T: YaSerialize>(
   _config: &Config,
 ) -> Result<W, String> {
   let mut serializer = Serializer::new_from_writer(writer);
-  match model.serialize(&mut serializer) {
+  match YaSerialize::serialize(model, &mut serializer) {
     Ok(()) => Ok(serializer.into_inner()),
     Err(msg) => Err(msg),
   }
@@ -46,7 +46,7 @@ pub fn serialize_with_writer_content<W: Write, T: YaSerialize>(
 ) -> Result<W, String> {
   let mut serializer = Serializer::new_for_inner(writer);
   serializer.set_skip_start_end(true);
-  match model.serialize(&mut serializer) {
+  match YaSerialize::serialize(model, &mut serializer) {
     Ok(()) => Ok(serializer.into_inner()),
     Err(msg) => Err(msg),
   }

--- a/yaserde_derive/src/de/expand_enum.rs
+++ b/yaserde_derive/src/de/expand_enum.rs
@@ -254,7 +254,7 @@ fn build_unnamed_visitor_calls(
 
       let call_struct_visitor = |struct_name, action| {
         Some(quote! {
-          match #struct_name::deserialize(reader) {
+          match <#struct_name as ::yaserde::YaDeserialize>::deserialize(reader) {
             Ok(value) => {
               #action;
               let _root = reader.next_event();

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -158,7 +158,7 @@ pub fn parse(
             }
             if let Ok(::xml::reader::XmlEvent::StartElement { .. }) = reader.peek() {
               // If substruct's start element found then deserialize substruct
-              let value = #struct_name::deserialize(reader)?;
+              let value = <#struct_name as ::yaserde::YaDeserialize>::deserialize(reader)?;
               #value_label #action;
             }
           }

--- a/yaserde_derive/src/ser/expand_enum.rs
+++ b/yaserde_derive/src/ser/expand_enum.rs
@@ -102,7 +102,7 @@ fn inner_enum_inspector(
                         ::std::option::Option::Some(#field_label_name.to_string()),
                       );
                       writer.set_skip_start_end(false);
-                      #field_label.serialize(writer)?;
+                      ::yaserde::YaSerialize::serialize(#field_label, writer)?;
                     },
                     _ => {}
                   }
@@ -115,7 +115,7 @@ fn inner_enum_inspector(
                           ::std::option::Option::Some(#field_label_name.to_string()),
                         );
                         writer.set_skip_start_end(false);
-                        item.serialize(writer)?;
+                        ::yaserde::YaSerialize::serialize(item, writer)?;
                       }
                     },
                     _ => {}
@@ -166,7 +166,7 @@ fn inner_enum_inspector(
               let serialize = quote! {
                 writer.set_start_event_name(::std::option::Option::None);
                 writer.set_skip_start_end(true);
-                item.serialize(writer)?;
+                ::yaserde::YaSerialize::serialize(item, writer)?;
               };
 
               let write_sub_type = |data_type| {

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -211,7 +211,7 @@ pub fn serialize(
               if let ::std::option::Option::Some(ref item) = &self.#label {
                 writer.set_start_event_name(::std::option::Option::None);
                 writer.set_skip_start_end(true);
-                item.serialize(writer)?;
+                ::yaserde::YaSerialize::serialize(item, writer)?;
               }
             }
           } else {
@@ -219,7 +219,7 @@ pub fn serialize(
               if let ::std::option::Option::Some(ref item) = &self.#label {
                 writer.set_start_event_name(::std::option::Option::Some(#label_name.to_string()));
                 writer.set_skip_start_end(false);
-                item.serialize(writer)?;
+                ::yaserde::YaSerialize::serialize(item, writer)?;
               }
             }
           }),
@@ -238,7 +238,7 @@ pub fn serialize(
           Some(quote! {
             writer.set_start_event_name(#start_event);
             writer.set_skip_start_end(#skip_start);
-            self.#label.serialize(writer)?;
+            ::yaserde::YaSerialize::serialize(&self.#label, writer)?;
           })
         }
         Field::FieldVec { data_type } => match *data_type {
@@ -277,7 +277,7 @@ pub fn serialize(
               if let Some(value) = item {
                 writer.set_start_event_name(None);
                 writer.set_skip_start_end(false);
-                value.serialize(writer)?;
+                ::yaserde::YaSerialize::serialize(value, writer)?;
               }
             }
           }),
@@ -287,7 +287,7 @@ pub fn serialize(
                 for item in &self.#label {
                     writer.set_start_event_name(::std::option::Option::None);
                   writer.set_skip_start_end(true);
-                  item.serialize(writer)?;
+                  ::yaserde::YaSerialize::serialize(item, writer)?;
                 }
               })
             } else {
@@ -295,7 +295,7 @@ pub fn serialize(
                 for item in &self.#label {
                   writer.set_start_event_name(::std::option::Option::Some(#label_name.to_string()));
                   writer.set_skip_start_end(false);
-                  item.serialize(writer)?;
+                  ::yaserde::YaSerialize::serialize(item, writer)?;
                 }
               })
             }
@@ -308,7 +308,7 @@ pub fn serialize(
             Some(quote! {
               writer.set_start_event_name(#start_event);
               writer.set_skip_start_end(#skip_start);
-              self.#label.serialize(writer)?;
+              ::yaserde::YaSerialize::serialize(&self.#label, writer)?;
             })*/
           }
           Field::FieldVec { .. } => {


### PR DESCRIPTION
Closes #103. See that issue for more details about the problem.