### PR TITLE
Allow adding the 'text' attribute to Option<String>

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -441,6 +441,26 @@ fn de_text_content_with_attributes() {
 }
 
 #[test]
+fn de_text_attribute_on_optional_string() {
+  #[derive(YaDeserialize, PartialEq, Debug)]
+  #[yaserde(rename = "base")]
+  pub struct XmlStruct {
+    #[yaserde(text)]
+    text: Option<String>,
+  }
+
+  let model = XmlStruct {
+    text: Some("Testing text".to_string()),
+  };
+  let content = r#"<base>Testing text</base>"#;
+  convert_and_validate!(content, XmlStruct, model);
+
+  let model = XmlStruct { text: None };
+  let content = r#"<base></base>"#;
+  convert_and_validate!(content, XmlStruct, model);
+}
+
+#[test]
 fn de_enum() {
   init();
 

--- a/yaserde/tests/flatten.rs
+++ b/yaserde/tests/flatten.rs
@@ -54,7 +54,7 @@ fn basic_flatten() {
     fn default() -> Self {
       DateKind::Working
     }
-  };
+  }
 
   let model = DateTime {
     date: Date {

--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -325,6 +325,28 @@ fn ser_text_content_with_attributes() {
 }
 
 #[test]
+fn ser_text_attribute_on_optional_string() {
+  #[derive(YaSerialize, PartialEq, Debug)]
+  #[yaserde(rename = "base")]
+  pub struct XmlStruct {
+    #[yaserde(text)]
+    text: Option<String>,
+  }
+
+  let model = XmlStruct {
+    text: Some("Testing text".to_string()),
+  };
+
+  let content = r#"<base>Testing text</base>"#;
+  serialize_and_validate!(model, content);
+
+  let model = XmlStruct { text: None };
+
+  let content = r#"<base></base>"#;
+  serialize_and_validate!(model, content);
+}
+
+#[test]
 fn ser_keyword() {
   #[derive(YaSerialize, PartialEq, Debug)]
   #[yaserde(rename = "base")]

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -303,7 +303,13 @@ pub fn parse(
 
       match field.get_type() {
         Field::FieldString => set_text(&quote! { text_content.to_owned() }),
-        Field::FieldStruct { .. } | Field::FieldOption { .. } | Field::FieldVec { .. } => None,
+        Field::FieldOption { data_type } => match *data_type {
+          Field::FieldString => set_text(
+            &quote! { if text_content.is_empty() { None } else { Some(text_content.to_owned()) }},
+          ),
+          _ => None,
+        },
+        Field::FieldStruct { .. } | Field::FieldVec { .. } => None,
         simple_type => {
           let type_token: TokenStream = simple_type.into();
           set_text(&quote! { #type_token::from_str(text_content).unwrap() })

--- a/yaserde_derive/src/lib.rs
+++ b/yaserde_derive/src/lib.rs
@@ -14,7 +14,7 @@ pub fn derive_deserialize(input: TokenStream) -> TokenStream {
   let ast = syn::parse(input).unwrap();
   match de::expand_derive_deserialize(&ast) {
     Ok(expanded) => expanded.into(),
-    Err(msg) => panic!(msg),
+    Err(msg) => panic!("{}", msg),
   }
 }
 
@@ -23,6 +23,6 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
   let ast = syn::parse(input).unwrap();
   match ser::expand_derive_serialize(&ast) {
     Ok(expanded) => expanded.into(),
-    Err(msg) => panic!(msg),
+    Err(msg) => panic!("{}", msg),
   }
 }


### PR DESCRIPTION
I use several of the same Rust structs for both JSON and XML serialization. I need certain properties in these structs to be optional for JSON serialization, but use the "text" attribute for XML. Previously this wasn't possible as yaserde didn't support the "text" attribute on anything but String and types that implemented `Into<TokenStream>`.

This PR adds support for serializing / deserializing the "text" of an XML tag into `Option<String>`. 

## Serialization
If an `Option<String>` is None, an empty string (the String Default impl) is written. 
If an `Option<String>` is Some, the inner string is written.

## Deserialization
If the XML text is an empty string, `None` is produced.
Else, `Some<text>` is produced.