### PR TITLE
Fix bug where nested structs with the same element names don't deserialize properly.

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -1052,6 +1052,5 @@ fn de_same_field_name_but_some_other_fields_or_something() {
   };
 
   serialize_and_validate!(model, content);
-  // TODO fix it
-  // deserialize_and_validate!(content, model, FooOuter);
+  deserialize_and_validate!(content, model, FooOuter);
 }

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -367,16 +367,23 @@ pub fn parse(
           );
           match event {
             ::xml::reader::XmlEvent::StartElement{ref name, ref attributes, ..} => {
-              match name.local_name.as_str() {
-                #call_visitors
-                _ => {
-                  let event = reader.next_event()?;
-                  #write_unused
+              if depth == 0 && name.local_name == #root {
+                // Consume root element. We must do this first. In the case it shares a name with a child element, we don't
+                // want to prematurely match the child element below.
+                let event = reader.next_event()?;
+                #write_unused
+              } else {
+                match name.local_name.as_str() {
+                  #call_visitors
+                  _ => {
+                    let event = reader.next_event()?;
+                    #write_unused
 
-                  if depth > 0 { // Don't skip root element
-                    reader.skip_element(|event| {
-                      #write_unused
-                    })?;
+                    if depth > 0 { // Don't skip root element
+                      reader.skip_element(|event| {
+                        #write_unused
+                      })?;
+                    }
                   }
                 }
               }


### PR DESCRIPTION

Fixes #110. 

Nested structs with the same field names don't deserialize correctly. #76 gives a more detailed description of the problem and provides a more comprehensive proposal for fixing it that involves a larger change to the internal workings of yaserde.

However, I needed a fix sooner than that large refactoring. This fix passes all tests including the test that checks this specific nested case.

 It moves the check for the root attribute above the checks for the child attributes, so we avoid matching on a child attribute with the same name as the root attribute when what we have actually pulled from the reader is the root attribute.

