### PR TITLE
Removed need for `xml-rs` and `log` in projects using yaserde

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,3 @@ edition = "2018"
 [dependencies]
 yaserde = {version = "0.7.0", path = "../yaserde" }
 yaserde_derive = {version = "0.7.0", path = "../yaserde_derive" }
-xml-rs = "0.8.3"
-log = "0.4"
-simple_logger = "1.11.0"

--- a/yaserde/src/lib.rs
+++ b/yaserde/src/lib.rs
@@ -57,10 +57,6 @@
 //! structs to compose the XML structure (again, see examples folder for the complete
 //! example).
 //!
-//! Be mindful that the **Cargo.toml** should not only include `yaserde` and
-//! `yaserde_derive`, but also `xml-rs` and `log` as your dependencies...
-//!
-//! [FIXME: Explain better why YaSerDe does not pull `xml-rs` and `log` automatically?](https://github.com/media-io/yaserde/issues/22)
 //!
 //!```toml
 //! [dependencies]
@@ -68,8 +64,6 @@
 //! # quick-xml = { version = "0.21.0", features = [ "serialize" ] }
 //! yaserde = "0.5.1"
 //! yaserde_derive = "0.5.1"
-//! xml-rs = "0.8.3"
-//! log = "0.4"
 //! ```
 //!
 //! Last but not least, in order to have a nice, pretty printed XML output one can do:
@@ -88,7 +82,8 @@
 //! XML.
 
 #[macro_use]
-extern crate log;
+pub extern crate log;
+pub extern crate xml;
 
 #[cfg(feature = "yaserde_derive")]
 #[allow(unused_imports)]

--- a/yaserde_derive/src/de/expand_enum.rs
+++ b/yaserde_derive/src/de/expand_enum.rs
@@ -32,14 +32,14 @@ pub fn parse(
         reader: &mut ::yaserde::de::Deserializer<R>,
       ) -> ::std::result::Result<Self, ::std::string::String> {
         let (named_element, enum_namespace) =
-          if let ::xml::reader::XmlEvent::StartElement{ name, .. } = reader.peek()?.to_owned() {
+          if let ::yaserde::xml::reader::XmlEvent::StartElement{ name, .. } = reader.peek()?.to_owned() {
             (name.local_name.to_owned(), name.namespace.clone())
           } else {
             (::std::string::String::from(#root), ::std::option::Option::None)
           };
 
         let start_depth = reader.depth();
-        ::log::debug!("Enum {} @ {}: start to parse {:?}", stringify!(#name), start_depth, named_element);
+        ::yaserde::log::debug!("Enum {} @ {}: start to parse {:?}", stringify!(#name), start_depth, named_element);
 
         #namespaces_matching
 
@@ -48,9 +48,9 @@ pub fn parse(
 
         loop {
           let event = reader.peek()?.to_owned();
-          ::log::trace!("Enum {} @ {}: matching {:?}", stringify!(#name), start_depth, event);
+          ::yaserde::log::trace!("Enum {} @ {}: matching {:?}", stringify!(#name), start_depth, event);
           match event {
-            ::xml::reader::XmlEvent::StartElement { ref name, ref attributes, .. } => {
+            ::yaserde::xml::reader::XmlEvent::StartElement { ref name, ref attributes, .. } => {
               match name.local_name.as_str() {
                 #match_to_enum
                 _named_element => {
@@ -58,23 +58,23 @@ pub fn parse(
                 }
               }
 
-              if let ::xml::reader::XmlEvent::Characters(content) = reader.peek()?.to_owned() {
+              if let ::yaserde::xml::reader::XmlEvent::Characters(content) = reader.peek()?.to_owned() {
                 match content.as_str() {
                   #match_to_enum
                   _ => {}
                 }
               }
             }
-            ::xml::reader::XmlEvent::EndElement { ref name } => {
+            ::yaserde::xml::reader::XmlEvent::EndElement { ref name } => {
               if name.local_name == named_element {
                 break;
               }
               let _root = reader.next_event();
             }
-            ::xml::reader::XmlEvent::Characters(ref text_content) => {
+            ::yaserde::xml::reader::XmlEvent::Characters(ref text_content) => {
               let _root = reader.next_event();
             }
-            ::xml::reader::XmlEvent::EndDocument => {
+            ::yaserde::xml::reader::XmlEvent::EndDocument => {
               if #flatten {
                 break;
               }
@@ -89,7 +89,7 @@ pub fn parse(
           }
         }
 
-        ::log::debug!("Enum {} @ {}: success", stringify!(#name), start_depth);
+        ::yaserde::log::debug!("Enum {} @ {}: success", stringify!(#name), start_depth);
         match enum_value {
           ::std::option::Option::Some(value) => ::std::result::Result::Ok(value),
           ::std::option::Option::None => {
@@ -231,11 +231,11 @@ fn build_unnamed_visitor_calls(
           let visitor = #visitor_label{};
 
           let result = reader.read_inner_value::<#field_type, _>(|reader| {
-            if let ::xml::reader::XmlEvent::EndElement { .. } = *reader.peek()? {
+            if let ::yaserde::xml::reader::XmlEvent::EndElement { .. } = *reader.peek()? {
               return visitor.#visitor("");
             }
 
-            if let ::std::result::Result::Ok(::xml::reader::XmlEvent::Characters(s))
+            if let ::std::result::Result::Ok(::yaserde::xml::reader::XmlEvent::Characters(s))
               = reader.next_event()
             {
               visitor.#visitor(&s)

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -156,7 +156,7 @@ pub fn parse(
               // Don't count current struct's StartElement as substruct's StartElement
               let _root = reader.next_event();
             }
-            if let Ok(::xml::reader::XmlEvent::StartElement { .. }) = reader.peek() {
+            if let Ok(::yaserde::xml::reader::XmlEvent::StartElement { .. }) = reader.peek() {
               // If substruct's start element found then deserialize substruct
               let value = <#struct_name as ::yaserde::YaDeserialize>::deserialize(reader)?;
               #value_label #action;
@@ -346,13 +346,13 @@ pub fn parse(
         reader: &mut ::yaserde::de::Deserializer<R>,
       ) -> ::std::result::Result<Self, ::std::string::String> {
         let (named_element, struct_namespace) =
-          if let ::xml::reader::XmlEvent::StartElement { name, .. } = reader.peek()?.to_owned() {
+          if let ::yaserde::xml::reader::XmlEvent::StartElement { name, .. } = reader.peek()?.to_owned() {
             (name.local_name.to_owned(), name.namespace.clone())
           } else {
             (::std::string::String::from(#root), ::std::option::Option::None)
           };
         let start_depth = reader.depth();
-        ::log::debug!("Struct {} @ {}: start to parse {:?}", stringify!(#name), start_depth,
+        ::yaserde::log::debug!("Struct {} @ {}: start to parse {:?}", stringify!(#name), start_depth,
                named_element);
 
         if reader.depth() == 0 {
@@ -367,12 +367,12 @@ pub fn parse(
 
         loop {
           let event = reader.peek()?.to_owned();
-          ::log::trace!(
+          ::yaserde::log::trace!(
             "Struct {} @ {}: matching {:?}",
             stringify!(#name), start_depth, event,
           );
           match event {
-            ::xml::reader::XmlEvent::StartElement{ref name, ref attributes, ..} => {
+            ::yaserde::xml::reader::XmlEvent::StartElement{ref name, ref attributes, ..} => {
               if depth == 0 && name.local_name == #root {
                 // Consume root element. We must do this first. In the case it shares a name with a child element, we don't
                 // want to prematurely match the child element below.
@@ -398,7 +398,7 @@ pub fn parse(
               }
               depth += 1;
             }
-            ::xml::reader::XmlEvent::EndElement { ref name } => {
+            ::yaserde::xml::reader::XmlEvent::EndElement { ref name } => {
               if name.local_name == named_element {
                 #write_unused
                 break;
@@ -407,12 +407,12 @@ pub fn parse(
               #write_unused
               depth -= 1;
             }
-            ::xml::reader::XmlEvent::EndDocument => {
+            ::yaserde::xml::reader::XmlEvent::EndDocument => {
               if #flatten {
                 break;
               }
             }
-            ::xml::reader::XmlEvent::Characters(ref text_content) => {
+            ::yaserde::xml::reader::XmlEvent::Characters(ref text_content) => {
               #set_text
               let event = reader.next_event()?;
               #write_unused
@@ -425,7 +425,7 @@ pub fn parse(
 
         #visit_unused
 
-        ::log::debug!("Struct {} @ {}: success", stringify!(#name), start_depth);
+        ::yaserde::log::debug!("Struct {} @ {}: success", stringify!(#name), start_depth);
         ::std::result::Result::Ok(#name{#struct_builder})
       }
     }
@@ -456,7 +456,7 @@ fn build_call_visitor(
       #namespaces_matching
 
       let result = reader.read_inner_value::<#field_type, _>(|reader| {
-        if let ::std::result::Result::Ok(::xml::reader::XmlEvent::Characters(s)) = reader.peek() {
+        if let ::std::result::Result::Ok(::yaserde::xml::reader::XmlEvent::Characters(s)) = reader.peek() {
           let val = visitor.#visitor(&s);
           let _event = reader.next_event()?;
           val
@@ -504,7 +504,7 @@ fn build_code_for_unused_xml_events(
   (
     Some(quote! {
       let mut buf = ::std::vec![];
-      let mut writer = ::std::option::Option::Some(::xml::writer::EventWriter::new(&mut buf));
+      let mut writer = ::std::option::Option::Some(::yaserde::xml::writer::EventWriter::new(&mut buf));
     }),
     Some(quote! {
       if let ::std::option::Option::Some(ref mut w) = writer {

--- a/yaserde_derive/src/ser/element.rs
+++ b/yaserde_derive/src/ser/element.rs
@@ -16,14 +16,14 @@ pub fn enclose_characters(label: &Option<Ident>, label_name: String) -> TokenStr
 
 fn enclose_xml_event(label_name: String, yaserde_format: TokenStream) -> TokenStream {
   quote! {
-    let start_event = ::xml::writer::XmlEvent::start_element(#label_name);
+    let start_event = ::yaserde::xml::writer::XmlEvent::start_element(#label_name);
     writer.write(start_event).map_err(|e| e.to_string())?;
 
     let yaserde_value = #yaserde_format;
-    let data_event = ::xml::writer::XmlEvent::characters(&yaserde_value);
+    let data_event = ::yaserde::xml::writer::XmlEvent::characters(&yaserde_value);
     writer.write(data_event).map_err(|e| e.to_string())?;
 
-    let end_event = ::xml::writer::XmlEvent::end_element();
+    let end_event = ::yaserde::xml::writer::XmlEvent::end_element();
     writer.write(end_event).map_err(|e| e.to_string())?;
   }
 }

--- a/yaserde_derive/src/ser/expand_enum.rs
+++ b/yaserde_derive/src/ser/expand_enum.rs
@@ -42,7 +42,7 @@ fn inner_enum_inspector(
       match variant.fields {
         Fields::Unit => Some(quote! {
           &#name::#label => {
-            let data_event = ::xml::writer::XmlEvent::characters(#label_name);
+            let data_event = ::yaserde::xml::writer::XmlEvent::characters(#label_name);
             writer.write(data_event).map_err(|e| e.to_string())?;
           }
         }),
@@ -57,7 +57,7 @@ fn inner_enum_inspector(
 
               if field.is_text_content() {
                 return Some(quote!(
-                  let data_event = ::xml::writer::XmlEvent::characters(&self.#field_label);
+                  let data_event = ::yaserde::xml::writer::XmlEvent::characters(&self.#field_label);
                   writer.write(data_event).map_err(|e| e.to_string())?;
                 ));
               }
@@ -81,14 +81,14 @@ fn inner_enum_inspector(
                     match self {
                       &#name::#label { ref #field_label, .. } => {
                         let struct_start_event =
-                          ::xml::writer::XmlEvent::start_element(#field_label_name);
+                          ::yaserde::xml::writer::XmlEvent::start_element(#field_label_name);
                         writer.write(struct_start_event).map_err(|e| e.to_string())?;
 
                         let string_value = #field_label.to_string();
-                        let data_event = ::xml::writer::XmlEvent::characters(&string_value);
+                        let data_event = ::yaserde::xml::writer::XmlEvent::characters(&string_value);
                         writer.write(data_event).map_err(|e| e.to_string())?;
 
-                        let struct_end_event = ::xml::writer::XmlEvent::end_element();
+                        let struct_end_event = ::yaserde::xml::writer::XmlEvent::end_element();
                         writer.write(struct_end_event).map_err(|e| e.to_string())?;
                       },
                       _ => {},
@@ -142,24 +142,24 @@ fn inner_enum_inspector(
             .map(|field| {
               let write_element = |action: &TokenStream| {
                 quote! {
-                  let struct_start_event = ::xml::writer::XmlEvent::start_element(#label_name);
+                  let struct_start_event = ::yaserde::xml::writer::XmlEvent::start_element(#label_name);
                   writer.write(struct_start_event).map_err(|e| e.to_string())?;
 
                   #action
 
-                  let struct_end_event = ::xml::writer::XmlEvent::end_element();
+                  let struct_end_event = ::yaserde::xml::writer::XmlEvent::end_element();
                   writer.write(struct_end_event).map_err(|e| e.to_string())?;
                 }
               };
 
               let write_string_chars = quote! {
-                let data_event = ::xml::writer::XmlEvent::characters(item);
+                let data_event = ::yaserde::xml::writer::XmlEvent::characters(item);
                 writer.write(data_event).map_err(|e| e.to_string())?;
               };
 
               let write_simple_type = write_element(&quote! {
                 let s = item.to_string();
-                let data_event = ::xml::writer::XmlEvent::characters(&s);
+                let data_event = ::yaserde::xml::writer::XmlEvent::characters(&s);
                 writer.write(data_event).map_err(|e| e.to_string())?;
               });
 

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -125,7 +125,7 @@ pub fn serialize(
             quote!(
               let (attributes, namespace) = self.#label.serialize_attributes(
                 ::std::vec![],
-                ::xml::namespace::Namespace::empty(),
+                ::yaserde::xml::namespace::Namespace::empty(),
               )?;
               child_attributes_namespace.extend(&namespace);
               child_attributes.extend(attributes);
@@ -148,11 +148,11 @@ pub fn serialize(
         return match field.get_type() {
           Field::FieldOption { .. } => Some(quote!(
             let s = self.#label.as_deref().unwrap_or_default();
-            let data_event = ::xml::writer::XmlEvent::characters(s);
+            let data_event = ::yaserde::xml::writer::XmlEvent::characters(s);
             writer.write(data_event).map_err(|e| e.to_string())?;
           )),
           _ => Some(quote!(
-            let data_event = ::xml::writer::XmlEvent::characters(&self.#label);
+            let data_event = ::yaserde::xml::writer::XmlEvent::characters(&self.#label);
             writer.write(data_event).map_err(|e| e.to_string())?;
           )),
         };

--- a/yaserde_derive/src/ser/implement_serializer.rs
+++ b/yaserde_derive/src/ser/implement_serializer.rs
@@ -25,21 +25,21 @@ pub fn implement_serializer(
 
         if !#flatten && !skip {
           let mut child_attributes = ::std::vec![];
-          let mut child_attributes_namespace = ::xml::namespace::Namespace::empty();
+          let mut child_attributes_namespace = ::yaserde::xml::namespace::Namespace::empty();
 
           let yaserde_label = writer.get_start_event_name().unwrap_or_else(|| #root.to_string());
           let struct_start_event =
-            ::xml::writer::XmlEvent::start_element(yaserde_label.as_ref()) #namespaces_definition;
+            ::yaserde::xml::writer::XmlEvent::start_element(yaserde_label.as_ref()) #namespaces_definition;
           #append_attributes
 
-          let event: ::xml::writer::events::XmlEvent = struct_start_event.into();
+          let event: ::yaserde::xml::writer::events::XmlEvent = struct_start_event.into();
 
-          if let ::xml::writer::events::XmlEvent::StartElement {
+          if let ::yaserde::xml::writer::events::XmlEvent::StartElement {
             name,
             attributes,
             namespace,
           } = event {
-            let mut attributes: ::std::vec::Vec<::xml::attribute::OwnedAttribute> =
+            let mut attributes: ::std::vec::Vec<::yaserde::xml::attribute::OwnedAttribute> =
               attributes.into_owned().to_vec().iter().map(|k| k.to_owned()).collect();
             attributes.extend(child_attributes);
 
@@ -48,7 +48,7 @@ pub fn implement_serializer(
             let mut all_namespaces = namespace.into_owned();
             all_namespaces.extend(&child_attributes_namespace);
 
-            writer.write(::xml::writer::events::XmlEvent::StartElement{
+            writer.write(::yaserde::xml::writer::events::XmlEvent::StartElement{
               name,
               attributes: ::std::borrow::Cow::Owned(all_attributes),
               namespace: ::std::borrow::Cow::Owned(all_namespaces)
@@ -61,7 +61,7 @@ pub fn implement_serializer(
         #inner_inspector
 
         if !#flatten && !skip {
-          let struct_end_event = ::xml::writer::XmlEvent::end_element();
+          let struct_end_event = ::yaserde::xml::writer::XmlEvent::end_element();
           writer.write(struct_end_event).map_err(|e| e.to_string())?;
         }
 
@@ -70,27 +70,27 @@ pub fn implement_serializer(
 
       fn serialize_attributes(
         &self,
-        mut source_attributes: ::std::vec::Vec<::xml::attribute::OwnedAttribute>,
-        mut source_namespace: ::xml::namespace::Namespace,
+        mut source_attributes: ::std::vec::Vec<::yaserde::xml::attribute::OwnedAttribute>,
+        mut source_namespace: ::yaserde::xml::namespace::Namespace,
       ) -> ::std::result::Result<
-        (::std::vec::Vec<::xml::attribute::OwnedAttribute>, ::xml::namespace::Namespace),
+        (::std::vec::Vec<::yaserde::xml::attribute::OwnedAttribute>, ::yaserde::xml::namespace::Namespace),
         ::std::string::String
       > {
-        let mut child_attributes = ::std::vec::Vec::<::xml::attribute::OwnedAttribute>::new();
-        let mut child_attributes_namespace = ::xml::namespace::Namespace::empty();
+        let mut child_attributes = ::std::vec::Vec::<::yaserde::xml::attribute::OwnedAttribute>::new();
+        let mut child_attributes_namespace = ::yaserde::xml::namespace::Namespace::empty();
 
         let struct_start_event =
-          ::xml::writer::XmlEvent::start_element("temporary_element_to_generate_attributes")
+          ::yaserde::xml::writer::XmlEvent::start_element("temporary_element_to_generate_attributes")
           #namespaces_definition;
 
         #append_attributes
-        let event: ::xml::writer::events::XmlEvent = struct_start_event.into();
+        let event: ::yaserde::xml::writer::events::XmlEvent = struct_start_event.into();
 
-        if let ::xml::writer::events::XmlEvent::StartElement { attributes, namespace, .. } = event {
+        if let ::yaserde::xml::writer::events::XmlEvent::StartElement { attributes, namespace, .. } = event {
           source_namespace.extend(&namespace.into_owned());
           source_namespace.extend(&child_attributes_namespace);
 
-          let a: ::std::vec::Vec<::xml::attribute::OwnedAttribute> =
+          let a: ::std::vec::Vec<::yaserde::xml::attribute::OwnedAttribute> =
             attributes.into_owned().to_vec().iter().map(|k| k.to_owned()).collect();
           source_attributes.extend(a);
           source_attributes.extend(child_attributes);


### PR DESCRIPTION
This is achieved by exporting `xml-rs` and `log` from the `yaserde` crate which is already included in projects using `yaserde`.

Then `xml-rs` can be accessed by `::yaserde::xml` instead of `::xml` and `log` can be accessed by `::yaserde::log` instead of `::log`.

This fixes issue #22 and is an improvement to the developer experience of using this crate.