### PR TITLE
Fix flattened fields

### DIFF
--- a/yaserde/tests/flatten.rs
+++ b/yaserde/tests/flatten.rs
@@ -192,3 +192,42 @@ fn flatten_attribute() {
   serialize_and_validate!(model, content);
   deserialize_and_validate!(content, model, HtmlText);
 }
+
+#[test]
+fn flatten_attribute_and_child() {
+  init();
+
+  #[derive(Default, PartialEq, Debug, YaDeserialize, YaSerialize)]
+  struct Node {
+    #[yaserde(flatten)]
+    base: Base,
+    #[yaserde(child)]
+    value: StringValue,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaDeserialize, YaSerialize)]
+  struct Base {
+    #[yaserde(attribute)]
+    id: String,
+  }
+
+  #[derive(Default, PartialEq, Debug, YaDeserialize, YaSerialize)]
+  struct StringValue {
+    #[yaserde(text)]
+    string: String,
+  }
+
+  let model = Node {
+    base: Base {
+      id: "Foo".to_owned(),
+    },
+    value: StringValue {
+      string: "Bar".to_owned(),
+    },
+  };
+
+  let content = r#"<Node id="Foo"><value>Bar</value></Node>"#;
+
+  serialize_and_validate!(model, content);
+  deserialize_and_validate!(content, model, Node);
+}

--- a/yaserde_derive/src/de/expand_enum.rs
+++ b/yaserde_derive/src/de/expand_enum.rs
@@ -66,7 +66,7 @@ pub fn parse(
               }
             }
             ::yaserde::__xml::reader::XmlEvent::EndElement { ref name } => {
-              if name.local_name == named_element {
+              if name.local_name == named_element && reader.depth() == start_depth + 1 {
                 break;
               }
               let _root = reader.next_event();

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -401,7 +401,7 @@ pub fn parse(
               depth += 1;
             }
             ::yaserde::__xml::reader::XmlEvent::EndElement { ref name } => {
-              if name.local_name == named_element {
+              if name.local_name == named_element && reader.depth() == start_depth + 1 {
                 #write_unused
                 break;
               }

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -160,6 +160,8 @@ pub fn parse(
               // If substruct's start element found then deserialize substruct
               let value = <#struct_name as ::yaserde::YaDeserialize>::deserialize(reader)?;
               #value_label #action;
+              // read EndElement
+              let _event = reader.next_event()?;
             }
           }
         })


### PR DESCRIPTION
This pr fixes some bugs that could cause wrong events to be written to the buffer for unused xml events. When this happens the error is quietly discarded and deserializing flattened fields no longer works.

This pr only fixes the bugs that could allow the buffer to be corrupted. We should probably emit a warning when the buffer is corrupted.