### PR TITLE
use newly renamed traits

### DIFF
--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -1,5 +1,5 @@
 use crate::common::attribute::YaSerdeAttribute;
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::Span;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
@@ -89,7 +89,7 @@ impl YaSerdeField {
     Ident::new(
       &format!(
         "__Visitor_{}_{}",
-        label.replace(".", "_").to_camel_case(),
+        label.replace(".", "_").to_upper_camel_case(),
         struct_id
       ),
       self.get_span(),

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -1,6 +1,6 @@
 use crate::common::{Field, YaSerdeAttribute, YaSerdeField};
 use crate::de::build_default_value::build_default_value;
-use heck::CamelCase;
+use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{DataStruct, Ident};
@@ -489,7 +489,7 @@ fn build_visitor_ident(label: &str, span: Span, struct_name: Option<&syn::Path>)
   Ident::new(
     &format!(
       "__Visitor_{}_{}",
-      label.replace(".", "_").to_camel_case(),
+      label.replace(".", "_").to_upper_camel_case(),
       struct_id
     ),
     span,


### PR DESCRIPTION
The `heck` dependency was updated to `0.4.0` in https://github.com/media-io/yaserde/pull/130. That release was a breaking change. This pr fixes the compiler errors that have been introduced by upgrading heck.