### PR TITLE
Add "skip_serializing" attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This library will support XML de/ser-ializing with all specific features.
 - [x] **namespace**: defines the namespace of the field
 - [x] **rename**: be able to rename a field
 - [x] **root**: rename the based element. Used only at the XML root.
+- [x] **skip_serializing**: Exclude this field from the serialized output
 - [x] **skip_serializing_if**: Skip the serialisation for this field if the condition is true
 - [x] **text**: this field match to the text content
 

--- a/yaserde/tests/skip.rs
+++ b/yaserde/tests/skip.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate yaserde;
+#[macro_use]
+extern crate yaserde_derive;
+
+fn init() {
+  let _ = env_logger::builder().is_test(true).try_init();
+}
+
+#[test]
+fn skip_serializing() {
+  init();
+
+  #[derive(YaSerialize, PartialEq, Debug)]
+  #[yaserde(rename = "base")]
+  pub struct XmlStruct {
+    #[yaserde(skip_serializing)]
+    skipped_serializing: String,
+  }
+
+  let model = XmlStruct {
+    skipped_serializing: "skipped serializing".to_string(),
+  };
+
+  let content = "<base />";
+  serialize_and_validate!(model, content);
+}

--- a/yaserde_derive/src/common/attribute.rs
+++ b/yaserde_derive/src/common/attribute.rs
@@ -12,6 +12,7 @@ pub struct YaSerdeAttribute {
   pub namespaces: BTreeMap<Option<String>, String>,
   pub prefix: Option<String>,
   pub rename: Option<String>,
+  pub skip_serializing: bool,
   pub skip_serializing_if: Option<String>,
   pub text: bool,
 }
@@ -39,6 +40,7 @@ impl YaSerdeAttribute {
     let mut namespaces = BTreeMap::new();
     let mut prefix = None;
     let mut rename = None;
+    let mut skip_serializing = false;
     let mut skip_serializing_if = None;
     let mut text = false;
 
@@ -80,6 +82,9 @@ impl YaSerdeAttribute {
                 "rename" => {
                   rename = get_value(&mut attr_iter);
                 }
+                "skip_serializing" => {
+                  skip_serializing = true;
+                }
                 "skip_serializing_if" => {
                   skip_serializing_if = get_value(&mut attr_iter);
                 }
@@ -102,6 +107,7 @@ impl YaSerdeAttribute {
       namespaces,
       prefix,
       rename,
+      skip_serializing,
       skip_serializing_if,
       text,
     }
@@ -177,6 +183,7 @@ fn parse_empty_attributes() {
       namespaces: BTreeMap::new(),
       prefix: None,
       rename: None,
+      skip_serializing: false,
       skip_serializing_if: None,
       text: false,
     },
@@ -226,6 +233,7 @@ fn parse_attributes() {
       namespaces: BTreeMap::new(),
       prefix: None,
       rename: None,
+      skip_serializing: false,
       skip_serializing_if: None,
       text: false,
     },
@@ -275,6 +283,7 @@ fn only_parse_yaserde_attributes() {
       namespaces: BTreeMap::new(),
       prefix: None,
       rename: None,
+      skip_serializing: false,
       skip_serializing_if: None,
       text: false,
     },
@@ -327,6 +336,7 @@ fn parse_attributes_with_values() {
       namespaces,
       prefix: None,
       rename: None,
+      skip_serializing: false,
       skip_serializing_if: None,
       text: false,
     },

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -40,6 +40,10 @@ impl YaSerdeField {
     self.syn_field.ident.clone()
   }
 
+  pub fn is_skip_serializing(&self) -> bool {
+    self.attributes.skip_serializing
+  }
+
   pub fn get_value_label(&self) -> Option<syn::Ident> {
     self
       .syn_field


### PR DESCRIPTION
If it is present on a field, that field should not be included in the output
If both `skip_serializing` and `skip_serializing_if` are present,`skip_serializing` should take precedent.

This is my first time working with macros in Rust, so code review feedback is appreciated.

Implements #131 (from writing tests, I learned that `skip_deserializing` is the default behavior, so it and `skip` would not be useful additions)

This relies on #132 to compile and run tests. 