### PR TITLE
Fix unwrap being hit in macro when malicious input is given

### DIFF
--- a/yaserde/tests/option.rs
+++ b/yaserde/tests/option.rs
@@ -107,3 +107,30 @@ fn option_struct() {
   );
   test_for_type!(Option::<Test>, None, None);
 }
+
+#[test]
+fn option_bool_no_crash_on_bad_input() {
+  init();
+
+  #[derive(Debug, PartialEq, YaDeserialize, YaSerialize)]
+  struct Test {
+    field: SubTest,
+  }
+
+  #[derive(Debug, PartialEq, YaDeserialize, YaSerialize)]
+  struct SubTest {
+    #[yaserde(attribute)]
+    content: Option<bool>,
+  }
+
+  impl Default for SubTest {
+    fn default() -> Self {
+      SubTest { content: None }
+    }
+  }
+
+  let content = "<field><content>/<R/";
+  let result: Result<Test, String> = yaserde::de::from_str(content);
+
+  assert!(result.is_err());
+}

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -116,7 +116,7 @@ pub fn parse(
               self,
               v: &str,
             ) -> ::std::result::Result<Self::Value, ::std::string::String> {
-              ::std::result::Result::Ok(#field_type::from_str(#map_if_bool).unwrap())
+              #field_type::from_str(#map_if_bool).map_err(|e| e.to_string())
             }
           }
         })


### PR DESCRIPTION
I ran `cargo fuzz` on my code and noticed a crash in the deserializer code when malformed XML was deserialized. Instead of panicking due to the unwrap, return an error.