### PR TITLE
Fields mandatory unless specified otherwise

### DIFF
--- a/examples/src/boscop.rs
+++ b/examples/src/boscop.rs
@@ -61,24 +61,24 @@ pub struct Control {
   pub h: u32,
   #[yaserde(attribute)]
   pub color: String,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub scalef: f32,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub scalet: f32,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub local_off: bool,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub sp: bool,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub sr: bool,
   pub midi: Vec<Midi>,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub response: String,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub inverted: String,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub centered: String,
-  #[yaserde(attribute)]
+  #[yaserde(attribute, default)]
   pub norollover: String,
 }
 

--- a/yaserde/tests/flatten.rs
+++ b/yaserde/tests/flatten.rs
@@ -251,6 +251,7 @@ fn flatten_name_in_unknown_child() {
   }
 
   #[derive(PartialEq, Debug, YaDeserialize, YaSerialize)]
+  #[yaserde(default)]
   enum Value {
     Foo(FooStruct),
   }

--- a/yaserde/tests/namespace.rs
+++ b/yaserde/tests/namespace.rs
@@ -330,7 +330,8 @@ fn enum_namespace() {
   #[yaserde(
     rename = "root",
     prefix = "ns",
-    namespace = "ns: http://www.sample.com/ns/domain"
+    namespace = "ns: http://www.sample.com/ns/domain",
+    default
   )]
   pub enum XmlStruct {
     #[yaserde(prefix = "ns")]
@@ -362,7 +363,8 @@ fn enum_multi_namespaces() {
   #[yaserde(
     rename = "root",
     namespace = "ns1: http://www.sample.com/ns/domain1",
-    namespace = "ns2: http://www.sample.com/ns/domain2"
+    namespace = "ns2: http://www.sample.com/ns/domain2",
+    default
   )]
   pub enum XmlStruct {
     #[yaserde(prefix = "ns1")]
@@ -405,7 +407,8 @@ fn enum_attribute_namespace() {
   #[yaserde(
     rename = "rootA",
     prefix = "ns",
-    namespace = "ns: http://www.sample.com/ns/domain"
+    namespace = "ns: http://www.sample.com/ns/domain",
+    default
   )]
   pub enum XmlStruct {
     #[yaserde(prefix = "ns")]

--- a/yaserde_derive/src/common/attribute.rs
+++ b/yaserde_derive/src/common/attribute.rs
@@ -27,7 +27,7 @@ fn get_value(iter: &mut IntoIter) -> Option<String> {
       None
     }
   } else {
-    None
+    Some(String::new())
   }
 }
 

--- a/yaserde_derive/src/common/attribute.rs
+++ b/yaserde_derive/src/common/attribute.rs
@@ -27,7 +27,19 @@ fn get_value(iter: &mut IntoIter) -> Option<String> {
       None
     }
   } else {
-    Some(String::new())
+    None
+  }
+}
+
+fn get_value_or_default(iter: &mut IntoIter) -> Option<String> {
+  match (iter.next(), iter.next()) {
+    (Some(TokenTree::Punct(operator)), Some(TokenTree::Literal(value))) => if operator.as_char() == '=' {
+      Some(value.to_string().replace('"', ""))
+    } else {
+      None
+    },
+    (None, None) => Some(String::new()),
+    _ => None
   }
 }
 
@@ -57,7 +69,7 @@ impl YaSerdeAttribute {
                   attribute = true;
                 }
                 "default" => {
-                  default = get_value(&mut attr_iter);
+                  default = get_value_or_default(&mut attr_iter);
                 }
                 "default_namespace" => {
                   default_namespace = get_value(&mut attr_iter);

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -108,12 +108,15 @@ impl YaSerdeField {
     self.syn_field.span()
   }
 
-  pub fn get_default_function(&self) -> Option<Ident> {
-    self
-      .attributes
-      .default
-      .as_ref()
-      .map(|default| Ident::new(default, self.get_span()))
+  pub fn get_default_function(&self) -> Option<TokenStream> {
+    self.attributes.default.as_ref().map(|default| {
+      if default != "" {
+        let f = Ident::new(default, self.get_span());
+        quote!( #f )
+      } else {
+        quote!(std::default::Default::default)
+      }
+    })
   }
 
   pub fn get_skip_serializing_if_function(&self) -> Option<Ident> {

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -114,7 +114,8 @@ impl YaSerdeField {
         let f = Ident::new(default, self.get_span());
         quote!( #f )
       } else {
-        quote!(std::default::Default::default)
+        let field_type = &self.syn_field.ty;
+        quote!(<#field_type as std::default::Default>::default)
       }
     })
   }

--- a/yaserde_derive/src/de/build_default_value.rs
+++ b/yaserde_derive/src/de/build_default_value.rs
@@ -2,6 +2,24 @@ use crate::common::YaSerdeField;
 use proc_macro2::TokenStream;
 use quote::quote;
 
+pub fn build_value(field: &YaSerdeField, field_type: Option<TokenStream>) -> Option<TokenStream> {
+  let label = field.get_value_label();
+
+  let value = field
+    .get_default_function()
+    .map(|default_function| quote!(::std::option::Option::Some(#default_function())))
+    .unwrap_or_else(|| quote!(::std::option::Option::None));
+
+  let field_type = field_type
+    .map(|field_type| quote!(: std::option::Option<#field_type>))
+    .unwrap_or_default();
+
+  Some(quote! {
+    #[allow(unused_mut)]
+    let mut #label #field_type = #value;
+  })
+}
+
 pub fn build_default_value(
   field: &YaSerdeField,
   field_type: Option<TokenStream>,
@@ -12,7 +30,7 @@ pub fn build_default_value(
   let default_value = field
     .get_default_function()
     .map(|default_function| quote!(#default_function()))
-    .unwrap_or_else(|| quote!(#value));
+    .unwrap_or_else(|| value);
 
   let field_type = field_type
     .map(|field_type| quote!(: #field_type))

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -318,7 +318,7 @@ pub fn parse(
         Field::FieldStruct { .. } | Field::FieldVec { .. } => None,
         simple_type => {
           let type_token = TokenStream::from(simple_type);
-          set_text(&quote! { #type_token::from_str(text_content).unwrap() })
+          set_text(&quote! { Some(#type_token::from_str(text_content).unwrap()) })
         }
       }
     })

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -152,7 +152,8 @@ pub fn serialize(
             writer.write(data_event).map_err(|e| e.to_string())?;
           )),
           _ => Some(quote!(
-            let data_event = ::yaserde::__xml::writer::XmlEvent::characters(&self.#label);
+            let s = self.#label.to_string();
+            let data_event = ::yaserde::__xml::writer::XmlEvent::characters(&s);
             writer.write(data_event).map_err(|e| e.to_string())?;
           )),
         };


### PR DESCRIPTION
Implements #144.

Not happy yet with how some of the error handling is taking place. Most notably optional structs are set to `None` if they do not parse successfully.

Secondly this change is a major move from the current semantics of the crate. There should be a discussion on whether this is acceptable at all, and how to communicate clearly to users that whilst their code may still compile, input data will be rejected unless `#[yaserde(default)]` is added here and there.