### PR TITLE
fix: break from the loop after matching enum variant

### DIFF
--- a/yaserde_derive/src/de/expand_enum.rs
+++ b/yaserde_derive/src/de/expand_enum.rs
@@ -112,6 +112,7 @@ fn parse_variant(variant: &syn::Variant, name: &Ident) -> Option<TokenStream> {
     Fields::Unit => Some(quote! {
       #xml_element_name => {
         enum_value = ::std::option::Option::Some(#variant_name);
+        break;
       }
     }),
     Fields::Unnamed(ref fields) => {


### PR DESCRIPTION
Fixes #146