### PR TITLE
Support for generic fields in structs

### DIFF
--- a/yaserde/tests/generic.rs
+++ b/yaserde/tests/generic.rs
@@ -1,0 +1,24 @@
+use yaserde::{serialize_and_validate, YaSerialize};
+
+extern crate yaserde;
+#[macro_use]
+extern crate yaserde_derive;
+
+#[test]
+fn parametrized_field() {
+    #[derive(Debug, PartialEq, YaSerialize)]
+    #[yaserde(rename = "outer")]
+    pub struct Outer<T: YaSerialize> {
+        pub inner: T,
+    }
+
+    #[derive(Debug, PartialEq, YaSerialize)]
+    pub struct Inner {
+        #[yaserde(text)]
+        pub body: String,
+    }
+
+    let content = "<outer><inner>Test</inner></outer>";
+    let model = Outer { inner: Inner { body: "Test".to_owned() }};
+    serialize_and_validate!(model, content);
+}

--- a/yaserde_derive/src/ser/expand_enum.rs
+++ b/yaserde_derive/src/ser/expand_enum.rs
@@ -2,7 +2,7 @@ use crate::common::{Field, YaSerdeAttribute, YaSerdeField};
 use crate::ser::{implement_serializer::implement_serializer, label::build_label_name};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::DataEnum;
+use syn::{DataEnum, Generics};
 use syn::Fields;
 use syn::Ident;
 
@@ -88,6 +88,7 @@ pub fn serialize(
     name,
     root,
     root_attributes,
+    &Generics::default(),
     quote!(#variant_matches),
     quote!(match self {
       #inner_enum_inspector

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -3,7 +3,7 @@ use crate::common::{Field, YaSerdeAttribute, YaSerdeField};
 use crate::ser::{element::*, implement_serializer::implement_serializer};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::DataStruct;
+use syn::{DataStruct, Generics};
 use syn::Ident;
 
 pub fn serialize(
@@ -11,6 +11,7 @@ pub fn serialize(
   name: &Ident,
   root: &str,
   root_attributes: &YaSerdeAttribute,
+  generics: &Generics,
 ) -> TokenStream {
   let append_attributes: TokenStream = data_struct
     .fields
@@ -346,6 +347,7 @@ pub fn serialize(
     name,
     root,
     root_attributes,
+    generics,
     append_attributes,
     struct_inspector,
   )

--- a/yaserde_derive/src/ser/implement_serializer.rs
+++ b/yaserde_derive/src/ser/implement_serializer.rs
@@ -3,19 +3,23 @@ use crate::ser::namespace::generate_namespaces_definition;
 use proc_macro2::Ident;
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::Generics;
 
 pub fn implement_serializer(
   name: &Ident,
   root: &str,
   attributes: &YaSerdeAttribute,
+  generics: &Generics,
   append_attributes: TokenStream,
   inner_inspector: TokenStream,
 ) -> TokenStream {
   let namespaces_definition = generate_namespaces_definition(attributes);
   let flatten = attributes.flatten;
 
+  let (impl_generics, type_generics, _) = generics.split_for_impl();
+
   quote! {
-    impl ::yaserde::YaSerialize for #name {
+    impl #impl_generics ::yaserde::YaSerialize for #name #type_generics {
       #[allow(unused_variables)]
       fn serialize<W: ::std::io::Write>(
         &self,

--- a/yaserde_derive/src/ser/mod.rs
+++ b/yaserde_derive/src/ser/mod.rs
@@ -13,6 +13,7 @@ pub fn expand_derive_serialize(ast: &syn::DeriveInput) -> Result<TokenStream, St
   let name = &ast.ident;
   let attrs = &ast.attrs;
   let data = &ast.data;
+  let generics = &ast.generics;
 
   let root_attributes = YaSerdeAttribute::parse(attrs);
 
@@ -24,7 +25,7 @@ pub fn expand_derive_serialize(ast: &syn::DeriveInput) -> Result<TokenStream, St
 
   let impl_block = match *data {
     syn::Data::Struct(ref data_struct) => {
-      expand_struct::serialize(data_struct, name, &root_name, &root_attributes)
+      expand_struct::serialize(data_struct, name, &root_name, &root_attributes, generics)
     }
     syn::Data::Enum(ref data_enum) => {
       expand_enum::serialize(data_enum, name, &root_name, &root_attributes)


### PR DESCRIPTION
I need this one to support `<xs:any/>` XSD elements, so that the callers might decide what they expect themselves. I'm not yet sure how this should look in final form, as there may be many `any`s, submitting this PR as a general idea.

TODOs:
[] support for parameters in struct serialization
[] support for parameters in struct deserialization
[] support for parameters in enums
[] instead of requiring `: YaSerialize` at type def level, add it in macro result at trait impl level