### PR TITLE
Fix tests

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -870,8 +870,7 @@ fn de_subitem_issue_12() {
   }
 
   convert_and_validate!(
-    r#"
-    <?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="utf-8"?>
     <Struct>
       <id>54</id>
       <SubStruct>
@@ -901,8 +900,7 @@ fn de_subitem_issue_12_with_sub() {
   }
 
   convert_and_validate!(
-    r#"
-    <?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="utf-8"?>
     <Struct>
       <id>54</id>
       <SubStruct>
@@ -929,8 +927,7 @@ fn de_subitem_issue_12_attributes() {
   }
 
   convert_and_validate!(
-    r#"
-    <?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="utf-8"?>
     <Struct id="54">
       <SubStruct id="86" />
     </Struct>
@@ -959,8 +956,7 @@ fn de_subitem_issue_12_attributes_with_sub() {
   }
 
   convert_and_validate!(
-    r#"
-    <?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="utf-8"?>
     <Struct id="54">
       <sub1 id="63" />
       <sub2 id="72" />

--- a/yaserde/tests/errors.rs
+++ b/yaserde/tests/errors.rs
@@ -41,6 +41,6 @@ fn de_wrong_end_balise() {
   let loaded: Result<Book, String> = from_str(content);
   assert_eq!(
     loaded,
-    Err("Unexpected closing tag: book, expected author".to_owned())
+    Err("Unexpected closing tag: book != author".to_owned())
   );
 }


### PR DESCRIPTION
Some tests in the current HEAD fail, at least when I try it.
 - The XML declarations for a few tests do not start at the beginning of the input
 - An error message appears to have changed regarding mismatching start and end element names

This PR fixes that.