### PR TITLE
Make `From<PathSegment> for Field` handle a corner case

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -1086,3 +1086,20 @@ fn de_attribute_sequence() {
   //serialize_and_validate!(model, content);
   deserialize_and_validate!(content, model, Outer);
 }
+
+#[test]
+fn de_nested_macro_rules() {
+  init!();
+
+  macro_rules! float_attrs {
+    ($type:ty) => {
+      #[derive(Default, PartialEq, Debug, YaDeserialize)]
+      pub struct Outer{
+        #[yaserde(attribute)]
+        pub inner: Option<$type>,
+      }
+    };
+  }
+
+  float_attrs!(f32);
+}

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -250,11 +250,20 @@ impl From<&syn::Field> for Field {
 impl From<&syn::PathSegment> for Field {
   fn from(path_segment: &syn::PathSegment) -> Self {
     if let syn::PathArguments::AngleBracketed(ref args) = path_segment.arguments {
-      if let Some(syn::GenericArgument::Type(Path(ref path))) = args.args.first() {
-        return Field::from(&path.path);
+      match args.args.first() {
+        Some(syn::GenericArgument::Type(Path(ref path))) => {
+          return Field::from(&path.path);
+        },
+        Some(syn::GenericArgument::Type(syn::Type::Group(syn::TypeGroup { elem, ..}))) => {
+          if let syn::Type::Path(ref group) = elem.as_ref() {
+            return Field::from(&group.path);
+          }
+        },
+        _ => unimplemented!("unable to match '{:?}'", args.args.first()),
       }
     }
-    unimplemented!()
+
+    unimplemented!("unable to match '{}'", quote!{#path_segment})
   }
 }
 


### PR DESCRIPTION
Handles a corner-case as outlined in the added test.