### PR TITLE
Add struct name to required field error

### DIFF
--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -347,11 +347,12 @@ pub fn parse(
             quote! { #label: #value_label.unwrap_or_else(|| #default_function()), }
           } else {
             let error = format!(
-              "{} is a required field",
+              "{} is a required field of {}",
               label
                 .as_ref()
                 .map(|label| label.to_string())
-                .unwrap_or_default()
+                .unwrap_or_default(),
+              name
             );
 
             quote! { #label: #value_label.ok_or_else(|| #error.to_string())?, }


### PR DESCRIPTION
Add some context to find missing required fields in large xmls where the field name is not sufficient to identify the struct