### PR TITLE
Example for custom serializer based on YaSerialize trait

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,4 +8,5 @@ description = "Examples for YaSerDe project"
 documentation = "https://docs.rs/yaserde"
 
 [dependencies]
+xml = "0.8.20"
 yaserde = {version = "0.10.0", path = "../yaserde", features = ["yaserde_derive"] }

--- a/examples/src/custom_serializer_ab.rs
+++ b/examples/src/custom_serializer_ab.rs
@@ -1,0 +1,195 @@
+use yaserde::{YaDeserialize, YaSerialize};
+
+#[derive(Debug, YaDeserialize)]
+struct RootElem {
+  #[yaserde()]
+  children: Vec<AB>,
+  // children are filtered by A and B
+  // this is usually not desired
+  #[yaserde()]
+  a_children: Vec<A>,
+  #[yaserde()]
+  b_children: Vec<B>,
+}
+impl YaSerialize for RootElem {
+  fn serialize<W: std::io::prelude::Write>(
+    &self,
+    writer: &mut yaserde::ser::Serializer<W>,
+  ) -> Result<(), String> {
+    writer.write("Root {\n").unwrap();
+    for e in &self.children {
+      e.serialize(writer).unwrap();
+    }
+    writer.write("/* only A elements */\n").unwrap();
+    for e in &self.a_children {
+      e.serialize(writer).unwrap();
+    }
+    writer.write("/* only B elements */\n").unwrap();
+    for e in &self.b_children {
+      e.serialize(writer).unwrap();
+    }
+    writer.write("}\n").unwrap();
+    Ok(())
+  }
+
+  fn serialize_attributes(
+    &self,
+    attributes: Vec<xml::attribute::OwnedAttribute>,
+    namespace: xml::namespace::Namespace,
+  ) -> Result<
+    (
+      Vec<xml::attribute::OwnedAttribute>,
+      xml::namespace::Namespace,
+    ),
+    String,
+  > {
+    Ok((attributes, namespace))
+  }
+}
+
+#[derive(Debug, YaDeserialize)]
+struct A {
+  #[yaserde(attribute)]
+  attr: String,
+}
+impl YaSerialize for A {
+  fn serialize<W: std::io::prelude::Write>(
+    &self,
+    writer: &mut yaserde::ser::Serializer<W>,
+  ) -> Result<(), String> {
+    writer.write("A {").unwrap();
+    writer
+      .write(format!("attr: {:?},", self.attr.as_str()).as_str())
+      .unwrap();
+    writer.write("}\n").unwrap();
+    Ok(())
+  }
+
+  fn serialize_attributes(
+    &self,
+    attributes: Vec<xml::attribute::OwnedAttribute>,
+    namespace: xml::namespace::Namespace,
+  ) -> Result<
+    (
+      Vec<xml::attribute::OwnedAttribute>,
+      xml::namespace::Namespace,
+    ),
+    String,
+  > {
+    Ok((attributes, namespace))
+  }
+}
+
+#[derive(Debug, YaDeserialize)]
+struct B {}
+impl YaSerialize for B {
+  fn serialize<W: std::io::prelude::Write>(
+    &self,
+    writer: &mut yaserde::ser::Serializer<W>,
+  ) -> Result<(), String> {
+    writer.write("B {}\n").unwrap();
+    Ok(())
+  }
+
+  fn serialize_attributes(
+    &self,
+    attributes: Vec<xml::attribute::OwnedAttribute>,
+    namespace: xml::namespace::Namespace,
+  ) -> Result<
+    (
+      Vec<xml::attribute::OwnedAttribute>,
+      xml::namespace::Namespace,
+    ),
+    String,
+  > {
+    Ok((attributes, namespace))
+  }
+}
+
+#[derive(Debug, Default, YaDeserialize)]
+enum AB {
+  #[default]
+  None,
+  A(A),
+  B(B),
+}
+
+impl YaSerialize for AB {
+  fn serialize<W: std::io::prelude::Write>(
+    &self,
+    writer: &mut yaserde::ser::Serializer<W>,
+  ) -> Result<(), String> {
+    writer.write("/* serialized AB */\n").unwrap();
+    match self {
+      Self::None => (),
+      Self::A(_a) => {
+        writer.write("A {").unwrap();
+      }
+      Self::B(_b) => {
+        writer.write("B {").unwrap();
+      }
+    }
+    writer.write("}\n").unwrap();
+    Ok(())
+  }
+
+  fn serialize_attributes(
+    &self,
+    attributes: Vec<xml::attribute::OwnedAttribute>,
+    namespace: xml::namespace::Namespace,
+  ) -> Result<
+    (
+      Vec<xml::attribute::OwnedAttribute>,
+      xml::namespace::Namespace,
+    ),
+    String,
+  > {
+    Ok((attributes, namespace))
+  }
+}
+
+#[test]
+fn serialize_ab() {
+  use std::fs;
+
+  let content =
+    fs::read_to_string("tests/data/ab.xml").expect("something went wrong reading the file");
+  let loaded: RootElem = yaserde::de::from_str(&content).unwrap();
+  println!("{:?}", &loaded);
+  let yaserde_conf = yaserde::ser::Config {
+    indent_string: Some(String::from("  ")),
+    perform_indent: true,
+    write_document_declaration: false,
+  };
+  let result = yaserde::ser::to_string_with_config(&loaded, &yaserde_conf).unwrap();
+  println!("\n\nSerialized output:\n{:?}", &result);
+  assert_eq!(
+    result,
+    r##"Root {
+A{}
+B{}
+A{}
+B{}
+A{}
+B{}
+B{}
+B{}
+B{}
+A{}
+B{}
+/* only A elements */
+A{}
+A{}
+A{}
+A{}
+/* only B elements */ 
+B{}
+B{}
+B{}
+B{}
+B{}
+B{}
+B{}
+}"##,
+  )
+}

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,4 +1,5 @@
 mod bbigras_namespace;
 mod boscop;
+mod custom_serializer_ab;
 mod ln_dom;
 mod svd;

--- a/examples/tests/data/ab.xml
+++ b/examples/tests/data/ab.xml
@@ -1,0 +1,18 @@
+<!--
+Description: Example serializing mixed A,B elements
+             The elements must be in sequence [A,B,A,B,A,B,B,B,B,A,B]
+ -->
+
+<RootElem>
+<A attr="hello 1"/>
+<B/>
+<A attr="hello 2"/>
+<B/>
+<A attr="hello 3"/>
+<B/>
+<B/>
+<B/>
+<B/>
+<A attr="hello 4"/>
+<B/>
+</RootElem>


### PR DESCRIPTION
NOTE: The test fails on purpose to help with integration.

When serializing to a custom (non-XML) output format users often expect that the element order is unchanged.
This can be difficult when using simple "Vec<A>" struct fields.

```rust
// Assuming ChildElemA/B are YaSerde structs
struct ChildElemA {}
struct ChildElemB {}

#[derive(yaserde_derive::YaSerialize)
struct SomeElem {
  #[yaserde()]
  a_children: Vec<ChildElemA>,  // this changes the order…
  b_children: Vec<ChildElemA>,  // …of child elements
}
```

The example shows one idea to solve this by putting the ChildElemA/B structs inside a "dispatcher" enum.

```rust
#[Deafult, YaSerialize]
enum OneOfAorB {
  #[default]
  None,
  ChildElemA(ChildElemA),
  ChildElemB(ChildElemA),
}
impl YaSerializer for OneOfAorB {
  fn serialize(&self, /* … */) {
    match self {
      Self::None => (),
      Self::ChildElemA(a) => { a.serialize().unwrap(); }
      Self::ChildElemB(b) => { b.serialize().unwrap(); }
    }
  }
}
```

:warning: Right now it is unclear if YaSerde supports this. Also the example may need adjustments.