### PR TITLE
wip: Strict deserialization returns error on any unknown xml field

### DIFF
--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -1117,3 +1117,20 @@ fn de_nested_macro_rules() {
 
   float_attrs!(f32);
 }
+
+#[test]
+fn de_strict() {
+  init();
+
+  #[derive(PartialEq, Debug, YaDeserialize)]
+  pub struct Struct {
+    id: i32,
+  }
+  let xml_content = r#"<?xml version="1.0" encoding="utf-8"?>
+      <Struct>
+          <id>123</id>
+          <NonExistentAttrShouldCrash></NonExistentAttrShouldCrash>
+        </Struct>"#;
+  let load: Result<Struct, String> = from_str(xml_content);
+  assert!(load.is_err());
+}

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -431,6 +431,9 @@ pub fn parse(
                 match (namespace.as_str(), name.local_name.as_str()) {
                   #call_visitors
                   _ => {
+                    ::yaserde::__derive_trace!("SKIPPINGSKIPPING  Skipping element {:?}", name.local_name);
+                    return Err(format!("Found unauthorized element {}", name.local_name));
+
                     let event = reader.next_event()?;
                     #write_unused
 


### PR DESCRIPTION
This is a feature request with some sample code to support the idea.

I am creating a strict parser that will deserialize a rather large configuration file from a running environment, modify it and write it back.

I need to be 100% sure that I won't be modifying anything else and I want complete type safety so I decided to go with yaserde.

However, I tried setting `#[yaserde(deny_unknown_fields)]` but it does nothing (or I don't understand what it should be doing).

#### Question 1 : Is this an existing feature that I missed ?

#### Question 2 : Is [this catch all case of the event name](https://github.com/media-io/yaserde/commit/353558737f3ef73e93164c596ff920d4344f30a3#diff-2adfb547cf85c7a52bafc55d16c40f3b12fc0da9882eb634db901d4aa259df45R435) the right place to `return Err(...)` ?

If so, I may very well try to make a cleaner implementation based on deny_unknown_fields if that sounds correct to you.