### PR TITLE
CDATA attribute

### DIFF
--- a/yaserde/src/ser/mod.rs
+++ b/yaserde/src/ser/mod.rs
@@ -71,7 +71,7 @@ impl<W: Write> Serializer<W> {
 
   pub fn new_from_writer(writer: W, config: &Config) -> Self {
     let mut emitter_config = EmitterConfig::new()
-      .cdata_to_characters(true)
+      .cdata_to_characters(false)
       .perform_indent(config.perform_indent)
       .write_document_declaration(config.write_document_declaration);
 

--- a/yaserde/tests/cdata.rs
+++ b/yaserde/tests/cdata.rs
@@ -1,0 +1,30 @@
+use yaserde_derive::{YaDeserialize, YaSerialize};
+
+fn init() {
+    let _ = env_logger::builder().is_test(true).try_init();
+  }
+
+#[derive(YaSerialize, YaDeserialize, PartialEq, Debug)]
+    #[yaserde(rename = "teststruct")]
+    struct TestStruct {
+    #[yaserde(cdata)]
+    pub msgdata: String,
+}
+
+#[test]
+fn test_cdata_serialization() {
+    init();
+
+    let test_data = TestStruct {
+        msgdata: "<tag>Some unescaped content</tag>".to_string(),
+    };
+
+    // Serialize to XML
+    let xml_output = yaserde::ser::to_string(&test_data).expect("Serialization failed");
+
+    // Expected XML with CDATA
+    let expected_output = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
+
+    // Assert that the output matches the expected CDATA-wrapped XML
+    assert_eq!(xml_output, expected_output);
+}

--- a/yaserde/tests/cdata.rs
+++ b/yaserde/tests/cdata.rs
@@ -21,3 +21,14 @@ fn test_cdata_serialization() {
   let expected_output = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
   assert_eq!(xml_output, expected_output);
 }
+
+#[test]
+fn test_cdata_deserialization() {
+  init();
+  let xml = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
+  let r: TestStruct = yaserde::de::from_str(&xml).unwrap();
+  let expected_output = TestStruct {
+    msgdata: "<tag>Some unescaped content</tag>".to_string(),
+  };
+  assert_eq!(r, expected_output);
+}

--- a/yaserde/tests/cdata.rs
+++ b/yaserde/tests/cdata.rs
@@ -1,30 +1,23 @@
 use yaserde_derive::{YaDeserialize, YaSerialize};
 
 fn init() {
-    let _ = env_logger::builder().is_test(true).try_init();
-  }
+  let _ = env_logger::builder().is_test(true).try_init();
+}
 
 #[derive(YaSerialize, YaDeserialize, PartialEq, Debug)]
-    #[yaserde(rename = "teststruct")]
-    struct TestStruct {
-    #[yaserde(cdata)]
-    pub msgdata: String,
+#[yaserde(rename = "teststruct")]
+struct TestStruct {
+  #[yaserde(cdata)]
+  pub msgdata: String,
 }
 
 #[test]
 fn test_cdata_serialization() {
-    init();
-
-    let test_data = TestStruct {
-        msgdata: "<tag>Some unescaped content</tag>".to_string(),
-    };
-
-    // Serialize to XML
-    let xml_output = yaserde::ser::to_string(&test_data).expect("Serialization failed");
-
-    // Expected XML with CDATA
-    let expected_output = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
-
-    // Assert that the output matches the expected CDATA-wrapped XML
-    assert_eq!(xml_output, expected_output);
+  init();
+  let test_data = TestStruct {
+    msgdata: "<tag>Some unescaped content</tag>".to_string(),
+  };
+  let xml_output = yaserde::ser::to_string(&test_data).expect("Serialization failed");
+  let expected_output = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
+  assert_eq!(xml_output, expected_output);
 }

--- a/yaserde_derive/src/common/attribute.rs
+++ b/yaserde_derive/src/common/attribute.rs
@@ -16,6 +16,7 @@ pub struct YaSerdeAttribute {
   pub skip_serializing: bool,
   pub skip_serializing_if: Option<String>,
   pub text: bool,
+  pub cdata: bool,
 }
 
 fn get_value(iter: &mut IntoIter) -> Option<String> {
@@ -45,6 +46,7 @@ impl YaSerdeAttribute {
     let mut skip_serializing = false;
     let mut skip_serializing_if = None;
     let mut text = false;
+    let mut cdata = false;
 
     for attr in attrs.iter().filter(|a| a.path.is_ident("yaserde")) {
       let mut attr_iter = attr.clone().tokens.into_iter();
@@ -96,6 +98,9 @@ impl YaSerdeAttribute {
                 "text" => {
                   text = true;
                 }
+                "cdata" => {
+                  cdata = true;
+                }
                 _ => {}
               }
             }
@@ -116,6 +121,7 @@ impl YaSerdeAttribute {
       skip_serializing,
       skip_serializing_if,
       text,
+      cdata,
     }
   }
 
@@ -192,6 +198,7 @@ fn parse_empty_attributes() {
       skip_serializing: false,
       skip_serializing_if: None,
       text: false,
+      cdata: false,
     },
     attrs
   );
@@ -243,6 +250,7 @@ fn parse_attributes() {
       skip_serializing: false,
       skip_serializing_if: None,
       text: false,
+      cdata: false
     },
     attrs
   );
@@ -294,6 +302,7 @@ fn only_parse_yaserde_attributes() {
       skip_serializing: false,
       skip_serializing_if: None,
       text: false,
+      cdata: false,
     },
     attrs
   );
@@ -351,6 +360,7 @@ fn parse_attributes_with_values() {
       skip_serializing: false,
       skip_serializing_if: None,
       text: false,
+      cdata: false,
     },
     attrs
   );

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -44,7 +44,7 @@ impl YaSerdeField {
     self.attributes.skip_serializing
   }
 
-  pub fn is_cdata(&self) -> bool{
+  pub fn is_cdata(&self) -> bool {
     self.attributes.cdata
   }
 

--- a/yaserde_derive/src/common/field.rs
+++ b/yaserde_derive/src/common/field.rs
@@ -44,6 +44,10 @@ impl YaSerdeField {
     self.attributes.skip_serializing
   }
 
+  pub fn is_cdata(&self) -> bool{
+    self.attributes.cdata
+  }
+
   pub fn get_value_label(&self) -> Option<syn::Ident> {
     self
       .syn_field

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -158,19 +158,19 @@ pub fn serialize(
           )),
         };
       }
-
-      
       let label_name = field.renamed_label(root_attributes);
       let conditions = condition_generator(&label, &field);
 
       if field.is_cdata() {
         return quote! {
-            let start_event = ::yaserde::__xml::writer::XmlEvent::start_element(#label_name);
-            writer.write(start_event).map_err(|e| e.to_string())?;
-            let data = ::yaserde::__xml::writer::events::XmlEvent::cdata(&self.#label);
-            writer.write(data).map_err(|e| e.to_string())?;
-            let end_event = ::yaserde::__xml::writer::XmlEvent::end_element();
-            writer.write(end_event).map_err(|e| e.to_string())?;
+            #conditions {
+              let start_event = ::yaserde::__xml::writer::XmlEvent::start_element(#label_name);
+              writer.write(start_event).map_err(|e| e.to_string())?;
+              let data = ::yaserde::__xml::writer::events::XmlEvent::cdata(&self.#label);
+              writer.write(data).map_err(|e| e.to_string())?;
+              let end_event = ::yaserde::__xml::writer::XmlEvent::end_element();
+              writer.write(end_event).map_err(|e| e.to_string())?;
+            }
         }.into()
       }
 
@@ -364,5 +364,3 @@ pub fn serialize(
     generics,
   )
 }
-
-

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -159,8 +159,20 @@ pub fn serialize(
         };
       }
 
+      
       let label_name = field.renamed_label(root_attributes);
       let conditions = condition_generator(&label, &field);
+
+      if field.is_cdata() {
+        return quote! {
+            let start_event = ::yaserde::__xml::writer::XmlEvent::start_element(#label_name);
+            writer.write(start_event).map_err(|e| e.to_string())?;
+            let data = ::yaserde::__xml::writer::events::XmlEvent::cdata(&self.#label);
+            writer.write(data).map_err(|e| e.to_string())?;
+            let end_event = ::yaserde::__xml::writer::XmlEvent::end_element();
+            writer.write(end_event).map_err(|e| e.to_string())?;
+        }.into()
+      }
 
       match field.get_type() {
         Field::FieldString
@@ -352,3 +364,5 @@ pub fn serialize(
     generics,
   )
 }
+
+


### PR DESCRIPTION
We are wanting to serialise a string as cdata at KSL and thought this might be a neat way to do it. 

Note i added  `.cdata_to_characters(false)` i was unsure if this would have any unintended consequences.