### PR TITLE
fix(deserialization): nested deserialization (#200)

### DIFF
--- a/examples/tests/data/svd.xml
+++ b/examples/tests/data/svd.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <device schemaversion="foo" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsnonamespaceschemalocation="CMSIS-SVD.xsd">
   <devattributes>
     <vendor>Renesas</vendor>

--- a/yaserde/src/de/mod.rs
+++ b/yaserde/src/de/mod.rs
@@ -18,6 +18,7 @@ pub struct Deserializer<R: Read> {
   depth: usize,
   reader: EventReader<R>,
   peeked: Option<XmlEvent>,
+  pub inner_struct_label: Option<&'static str>,
 }
 
 impl<R: Read> Deserializer<R> {
@@ -26,6 +27,7 @@ impl<R: Read> Deserializer<R> {
       depth: 0,
       reader,
       peeked: None,
+      inner_struct_label: None,
     }
   }
 

--- a/yaserde/src/lib.rs
+++ b/yaserde/src/lib.rs
@@ -328,7 +328,7 @@ macro_rules! serialize_and_validate {
     log::debug!("serialize_and_validate @ {}:{}", file!(), line!());
     let data: Result<String, String> = yaserde::ser::to_string(&$model);
 
-    let content = &format!(r#"<?xml version="1.0" encoding="utf-8"?>{}"#, $content);
+    let content = &format!(r#"<?xml version="1.0" encoding="UTF-8"?>{}"#, $content);
     assert_eq!(
       data,
       Ok(content.split("\n").map(|s| s.trim()).collect::<String>())

--- a/yaserde/tests/cdata.rs
+++ b/yaserde/tests/cdata.rs
@@ -18,14 +18,14 @@ fn test_cdata_serialization() {
     msgdata: "<tag>Some unescaped content</tag>".to_string(),
   };
   let xml_output = yaserde::ser::to_string(&test_data).expect("Serialization failed");
-  let expected_output = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
+  let expected_output = r#"<?xml version="1.0" encoding="UTF-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
   assert_eq!(xml_output, expected_output);
 }
 
 #[test]
 fn test_cdata_deserialization() {
   init();
-  let xml = r#"<?xml version="1.0" encoding="utf-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
+  let xml = r#"<?xml version="1.0" encoding="UTF-8"?><teststruct><msgdata><![CDATA[<tag>Some unescaped content</tag>]]></msgdata></teststruct>"#;
   let r: TestStruct = yaserde::de::from_str(xml).unwrap();
   let expected_output = TestStruct {
     msgdata: "<tag>Some unescaped content</tag>".to_string(),

--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -583,7 +583,7 @@ fn de_complex_enum() {
     Dotted(u32),
   }
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Black>text</Black>
@@ -598,7 +598,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Orange>text</Orange>
@@ -613,7 +613,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Red>56</Red>
@@ -628,7 +628,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Green>
@@ -646,7 +646,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Yellow>text</Yellow>
@@ -661,7 +661,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Brown>
@@ -679,7 +679,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Blue>abc</Blue>
@@ -695,7 +695,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Purple>12</Purple>
@@ -711,7 +711,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base>
       <background>
         <Magenta><fi>12</fi><se>23</se></Magenta>
@@ -730,7 +730,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base xmlns:ns="http://www.sample.com/ns/domain">
       <background>
         <NotSoCyan><fi>12</fi><se>23</se></NotSoCyan>
@@ -749,7 +749,7 @@ fn de_complex_enum() {
     }
   );
 
-  let content = r#"<?xml version="1.0" encoding="utf-8"?>
+  let content = r#"<?xml version="1.0" encoding="UTF-8"?>
     <base xmlns:ns="http://www.sample.com/ns/domain">
       <background>
         <renamed.with.dots>54</renamed.with.dots>
@@ -854,7 +854,7 @@ fn de_subitem_issue_12() {
   }
 
   convert_and_validate!(
-    r#"<?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="UTF-8"?>
     <Struct>
       <id>54</id>
       <SubStruct>
@@ -884,7 +884,7 @@ fn de_subitem_issue_12_with_sub() {
   }
 
   convert_and_validate!(
-    r#"<?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="UTF-8"?>
     <Struct>
       <id>54</id>
       <SubStruct>
@@ -911,7 +911,7 @@ fn de_subitem_issue_12_attributes() {
   }
 
   convert_and_validate!(
-    r#"<?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="UTF-8"?>
     <Struct id="54">
       <SubStruct id="86" />
     </Struct>
@@ -940,7 +940,7 @@ fn de_subitem_issue_12_attributes_with_sub() {
   }
 
   convert_and_validate!(
-    r#"<?xml version="1.0" encoding="utf-8"?>
+    r#"<?xml version="1.0" encoding="UTF-8"?>
     <Struct id="54">
       <sub1 id="63" />
       <sub2 id="72" />

--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -1196,3 +1196,54 @@ fn de_nested_3_levels() {
   };
   deserialize_and_validate!(content, model, A);
 }
+
+#[test]
+fn de_nested_issue_192() {
+  #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
+  #[yaserde(
+    prefix = "xs",
+    namespaces = {
+      "xs" = "http://www.w3.org/2001/XMLSchema",
+    }
+  )]
+  pub struct XSDGroup {
+    #[yaserde(rename = "ref", attribute = true)]
+    pub reference: String,
+  }
+
+  #[derive(Clone, Default, Debug, PartialEq, YaDeserialize)]
+  #[yaserde(
+    rename = "sequence",
+    prefix = "xs",
+    namespaces = {
+      "xs" = "http://www.w3.org/2001/XMLSchema",
+    }
+  )]
+  pub struct Sequence {
+    #[yaserde(rename = "group", prefix = "xs")]
+    pub groups: Vec<XSDGroup>,
+
+    #[yaserde(rename = "sequence", prefix = "xs")]
+    pub sequences: Vec<Sequence>,
+  }
+
+  let content = r#"
+        <xsd:sequence xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+          <xsd:group ref="AR:AR-OBJECT"/>
+          <xsd:group ref="AR:AUTOSAR"/>
+        </xsd:sequence>
+      "#;
+  let model = Sequence {
+    groups: vec![
+      XSDGroup {
+        reference: "AR:AR-OBJECT".to_string(),
+      },
+      XSDGroup {
+        reference: "AR:AUTOSAR".to_string(),
+      },
+    ],
+    sequences: vec![],
+  };
+
+  deserialize_and_validate!(content, model, Sequence);
+}

--- a/yaserde/tests/deserializer.rs
+++ b/yaserde/tests/deserializer.rs
@@ -1118,11 +1118,8 @@ fn de_nested_macro_rules() {
   float_attrs!(f32);
 }
 
-
 #[test]
 fn de_nested_element_equality() {
-
-
   #[derive(YaDeserialize, Debug, PartialEq)]
   #[yaserde(rename = "EBMLSchema")]
   struct Schema {
@@ -1140,10 +1137,10 @@ fn de_nested_element_equality() {
   #[derive(YaDeserialize, Debug, PartialEq)]
   #[yaserde(rename = "documentation")]
   struct Documentation {
-    #[yaserde(text=true)]
+    #[yaserde(text = true)]
     body: String,
   }
-  
+
   let parent = r#"<EBMLSchema>
 <element>
 <documentation>Test</documentation>
@@ -1155,42 +1152,47 @@ fn de_nested_element_equality() {
 <documentation>Test</documentation>
 </element>"#;
   let child: Element = yaserde::de::from_str(child).unwrap();
-  
+
   assert_ne!(parent.elements, vec![]);
   assert_eq!(parent.elements[0], child);
 }
 
 #[test]
-fn de_nested_3_levels(){
-
-  #[derive(YaSerialize,YaDeserialize,Debug,PartialEq)]
+fn de_nested_3_levels() {
+  #[derive(YaSerialize, YaDeserialize, Debug, PartialEq)]
   struct A {
     id: String,
     #[yaserde(rename = "SAME")]
-    many:Vec<B>
+    many: Vec<B>,
   }
 
-  #[derive(YaSerialize,YaDeserialize,Debug,PartialEq)]
+  #[derive(YaSerialize, YaDeserialize, Debug, PartialEq)]
   struct B {
     id: Option<String>,
     #[yaserde(rename = "SAME")]
-    many:Vec<C>
-
+    many: Vec<C>,
   }
 
-  #[derive(YaSerialize,YaDeserialize,Debug,PartialEq)]
+  #[derive(YaSerialize, YaDeserialize, Debug, PartialEq)]
   struct C {
     id: Option<String>,
   }
 
-  let content = r#"<A><id>a1</id><SAME><id>b1</id><SAME><id>c1</id></SAME><SAME><id>c2</id></SAME></SAME></A>"#;
-  let model =  A {
+  let content =
+    r#"<A><id>a1</id><SAME><id>b1</id><SAME><id>c1</id></SAME><SAME><id>c2</id></SAME></SAME></A>"#;
+  let model = A {
     id: "a1".to_string(),
-    many: vec![B { id: Some("b1".to_string()), many: vec![
-      C { id: Some("c1".to_string() )},
-      C { id: Some("c2".to_string() )},
-    ] }],
+    many: vec![B {
+      id: Some("b1".to_string()),
+      many: vec![
+        C {
+          id: Some("c1".to_string()),
+        },
+        C {
+          id: Some("c2".to_string()),
+        },
+      ],
+    }],
   };
   deserialize_and_validate!(content, model, A);
-
 }

--- a/yaserde/tests/option.rs
+++ b/yaserde/tests/option.rs
@@ -144,7 +144,7 @@ mod tests {
 
   #[test]
   fn deserialize_without_car() {
-    let person = r#"<?xml version="1.0" encoding="utf-8"?>
+    let person = r#"<?xml version="1.0" encoding="UTF-8"?>
       <Person>
           <EyeColor>brown</EyeColor>
           <Age>25</Age>

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -421,7 +421,7 @@ pub fn parse(
           match event {
             ::yaserde::__xml::reader::XmlEvent::StartElement{ref name, ref attributes, ..} => {
               let namespace = name.namespace.clone().unwrap_or_default();
-              if depth == 0 && name.local_name == #root && namespace.as_str() == #root_namespace {
+              if depth == 0  {
                 // Consume root element. We must do this first. In the case it shares a name with a child element, we don't
                 // want to prematurely match the child element below.
                 let event = reader.next_event()?;
@@ -457,9 +457,8 @@ pub fn parse(
               depth -= 1;
             }
             ::yaserde::__xml::reader::XmlEvent::EndDocument => {
-              if #flatten {
-                break;
-              }
+              // once we receive this once, we will keep getting it, potentially looping forever
+              break;
             }
             ::yaserde::__xml::reader::XmlEvent::Characters(ref text_content) => {
               #set_text

--- a/yaserde_derive/src/de/expand_struct.rs
+++ b/yaserde_derive/src/de/expand_struct.rs
@@ -7,7 +7,6 @@ use syn::{DataStruct, Generics, Ident};
 pub fn parse(
   data_struct: &DataStruct,
   name: &Ident,
-  root_namespace: &str,
   root: &str,
   root_attributes: &YaSerdeAttribute,
   generics: &Generics,
@@ -422,7 +421,7 @@ pub fn parse(
           match event {
             ::yaserde::__xml::reader::XmlEvent::StartElement{ref name, ref attributes, ..} => {
               let namespace = name.namespace.clone().unwrap_or_default();
-              if depth == 0 && name.local_name == root_label && namespace.as_str() == #root_namespace {
+              if depth == 0 && name.local_name == root_label {
                 // Consume root element. We must do this first. In the case it shares a name with a child element, we don't
                 // want to prematurely match the child element below.
                 let event = reader.next_event()?;

--- a/yaserde_derive/src/de/mod.rs
+++ b/yaserde_derive/src/de/mod.rs
@@ -17,13 +17,9 @@ pub fn expand_derive_deserialize(ast: &syn::DeriveInput) -> Result<TokenStream, 
   let root_name = root_attributes.xml_element_name(name);
 
   let impl_block = match *data {
-    syn::Data::Struct(ref data_struct) => expand_struct::parse(
-      data_struct,
-      name,
-      &root_name,
-      &root_attributes,
-      generics,
-    ),
+    syn::Data::Struct(ref data_struct) => {
+      expand_struct::parse(data_struct, name, &root_name, &root_attributes, generics)
+    }
     syn::Data::Enum(ref data_enum) => {
       expand_enum::parse(data_enum, name, &root_name, &root_attributes, generics)
     }

--- a/yaserde_derive/src/de/mod.rs
+++ b/yaserde_derive/src/de/mod.rs
@@ -15,23 +15,11 @@ pub fn expand_derive_deserialize(ast: &syn::DeriveInput) -> Result<TokenStream, 
   let root_attributes = YaSerdeAttribute::from(attrs);
 
   let root_name = root_attributes.xml_element_name(name);
-  let root_namespace = root_attributes
-    .namespaces
-    .iter()
-    .find_map(|(prefix, namespace)| {
-      if root_attributes.prefix.as_deref().eq(&Some(prefix)) {
-        Some(namespace.clone())
-      } else {
-        None
-      }
-    })
-    .unwrap_or_default();
 
   let impl_block = match *data {
     syn::Data::Struct(ref data_struct) => expand_struct::parse(
       data_struct,
       name,
-      &root_namespace,
       &root_name,
       &root_attributes,
       generics,


### PR DESCRIPTION
changes condition of start element next_event call for structs
always break for EndDocument

fixes #200

This kind of conflicts with #193, and we probably need to come up with a different solution. The problem is that we compare the name of the struct here with the local name, which will not work for renamed fields